### PR TITLE
[TICKET-001] Add Categories Database Schema

### DIFF
--- a/.development-context/ADRs/002-domain-driven-design-approach.md
+++ b/.development-context/ADRs/002-domain-driven-design-approach.md
@@ -1,0 +1,331 @@
+# ADR-002: Domain-Driven Design Approach
+
+## Status
+
+Accepted (2024-10-14)
+
+## Context
+
+Junction Bank is a personal finance management system with distinct business domains: Categories, Transactions, Months, Recurring Transactions, and Currency. The application needs a clear architectural pattern to:
+
+1. Manage complexity as features grow
+2. Maintain clear boundaries between domains
+3. Enable independent domain evolution
+4. Facilitate testing and maintenance
+5. Support multiple developers working concurrently
+
+Traditional MVC with "fat models" or "fat controllers" leads to:
+
+-   Tight coupling between layers
+-   Difficult testing
+-   Unclear business logic location
+-   Cross-cutting concerns mixed with domain logic
+-   Hard-to-navigate codebases
+
+## Decision
+
+We will implement Domain-Driven Design (DDD) principles with the following structure:
+
+### Domain Organization
+
+```
+app/Domains/{DomainName}/
+├── Actions/              # Business logic (use cases)
+├── DTOs/                 # Data transfer objects
+├── Models/               # Eloquent models
+├── Repositories/         # Data access layer
+│   ├── {Name}Repository.php           (interface)
+│   └── Eloquent{Name}Repository.php   (implementation)
+└── Policies/             # Authorization rules
+```
+
+### Layer Responsibilities
+
+**Controllers (HTTP Layer)**
+
+-   HTTP request/response handling
+-   Delegate to Actions
+-   No business logic
+-   Thin by design
+
+**Actions (Business Logic Layer)**
+
+-   Single responsibility use cases
+-   Orchestrate business operations
+-   Call repositories for data access
+-   Return domain models or DTOs
+
+**Repositories (Data Access Layer)**
+
+-   Abstract data persistence
+-   Hide Eloquent implementation details
+-   Enable testing with mocks
+-   Consistent query interface
+
+**DTOs (Data Transfer Objects)**
+
+-   Immutable data containers
+-   Type-safe data transfer between layers
+-   Validation at boundaries
+-   Factory methods from various sources
+
+**Models (Domain Models)**
+
+-   Eloquent models
+-   Stay within their domain
+-   Relationships only within domain or via IDs
+-   No cross-domain model imports
+
+### Dependency Flow
+
+```mermaid
+graph TB
+    HTTP[HTTP Request] --> Controller
+    Controller --> Action
+    Action --> Repository
+    Repository --> Model
+    Model --> DB[(Database)]
+
+    Action --> DTO[DTO]
+    Controller --> DTO
+
+    DTO -.-> Action
+    DTO -.-> Controller
+```
+
+### Key Principles
+
+1. **Controllers delegate to Actions**
+
+    - Controllers are thin
+    - Business logic lives in Actions
+
+2. **Actions contain business logic**
+
+    - Single responsibility
+    - Composable and testable
+    - Orchestrate operations
+
+3. **Repositories abstract data access**
+
+    - Interface-based
+    - Hide implementation details
+    - Mockable for testing
+
+4. **DTOs transfer data**
+
+    - Immutable by design (readonly)
+    - Type-safe
+    - Validated at creation
+
+5. **Domain isolation**
+    - No cross-domain model imports
+    - Use DTOs for inter-domain communication
+    - Each domain is self-contained
+
+## Consequences
+
+### Positive
+
+-   **Maintainability:** Clear separation of concerns makes code easier to understand and modify
+-   **Testability:** Each layer can be tested independently with mocks
+-   **Scalability:** Domains can evolve independently
+-   **Onboarding:** New developers can understand domain boundaries quickly
+-   **Code Quality:** Consistent patterns across all domains
+-   **Refactoring:** Changes contained within layer boundaries
+-   **Team Velocity:** Multiple developers can work on different domains without conflicts
+
+### Negative
+
+-   **Initial Overhead:** More files and structure than simple MVC
+-   **Learning Curve:** Team must understand DDD principles
+-   **Over-Engineering Risk:** Small features still require full structure
+-   **Boilerplate:** More interfaces and classes to maintain
+
+### Neutral
+
+-   **File Count:** Higher number of smaller files vs. fewer larger files
+-   **Directory Depth:** Deeper nesting vs. flat structure
+-   **Abstractions:** More interfaces and contracts
+
+## Alternatives Considered
+
+### Alternative 1: Traditional Laravel MVC
+
+**Description:** Standard Laravel structure with fat models or controllers
+
+**Pros:**
+
+-   Simpler initial setup
+-   Less boilerplate
+-   Familiar to Laravel developers
+-   Quick for small features
+
+**Cons:**
+
+-   Logic becomes scattered
+-   Tight coupling
+-   Hard to test
+-   Doesn't scale well
+-   Cross-cutting concerns mixed in
+
+**Why not chosen:** Won't scale as application grows. Multiple domains need clear boundaries.
+
+### Alternative 2: Action-Domain-Responder (ADR)
+
+**Description:** Refinement of MVC with Action classes and Responders
+
+**Pros:**
+
+-   Better than MVC
+-   Actions are testable
+-   Clear responsibility
+
+**Cons:**
+
+-   Less emphasis on domain boundaries
+-   Still couples to HTTP concerns
+-   No repository abstraction
+
+**Why not chosen:** DDD provides better domain isolation and is more comprehensive.
+
+### Alternative 3: Hexagonal/Ports & Adapters Architecture
+
+**Description:** Full ports and adapters with application/infrastructure split
+
+**Pros:**
+
+-   Maximum flexibility
+-   Complete isolation
+-   Technology agnostic
+
+**Cons:**
+
+-   Much more complex
+-   High overhead for web app
+-   Over-engineered for current needs
+-   Steep learning curve
+
+**Why not chosen:** Too complex for a Laravel web application. DDD provides sufficient structure without excessive abstraction.
+
+### Alternative 4: CQRS (Command Query Responsibility Segregation)
+
+**Description:** Separate read and write operations with distinct models
+
+**Pros:**
+
+-   Optimized read/write paths
+-   Scales well
+-   Clear intent
+
+**Cons:**
+
+-   Adds significant complexity
+-   Eventual consistency challenges
+-   Overkill for current scale
+-   Requires event sourcing infrastructure
+
+**Why not chosen:** Premature optimization. Can be added later if needed.
+
+## Implementation Guidelines
+
+### Example: Create Category
+
+**Controller:**
+
+```php
+public function store(CreateCategoryRequest $request): JsonResponse
+{
+    $category = $this->createCategory->execute(
+        CategoryData::fromRequest($request)
+    );
+
+    return response()->json($category, 201);
+}
+```
+
+**Action:**
+
+```php
+final class CreateCategoryAction
+{
+    public function __construct(
+        private readonly CategoryRepository $repository
+    ) {}
+
+    public function execute(CategoryData $data): Category
+    {
+        return $this->repository->create($data);
+    }
+}
+```
+
+**Repository:**
+
+```php
+interface CategoryRepository
+{
+    public function create(CategoryData $data): Category;
+}
+
+final class EloquentCategoryRepository implements CategoryRepository
+{
+    public function create(CategoryData $data): Category
+    {
+        return Category::create([
+            'name' => $data->name,
+            'type' => $data->type,
+            'notes' => $data->notes,
+        ]);
+    }
+}
+```
+
+**DTO:**
+
+```php
+final readonly class CategoryData
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public ?string $notes = null
+    ) {}
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            name: $request->string('name')->toString(),
+            type: $request->string('type')->toString(),
+            notes: $request->string('notes')->toString()
+        );
+    }
+}
+```
+
+## Migration Path
+
+For existing code not following DDD:
+
+1. Extract business logic from controllers into Actions
+2. Create DTOs for data transfer
+3. Implement Repository interfaces
+4. Update controllers to use Actions
+5. Test each layer independently
+6. Remove old controller logic
+
+## Success Metrics
+
+-   Controllers average < 10 lines per method
+-   Actions have single responsibility
+-   90%+ test coverage
+-   No cross-domain model imports
+-   New features follow pattern consistently
+
+## References
+
+-   [Development Rules: Domain-Driven Design](../rules/01-domain-driven-design.md)
+-   [Development Rules: Repository Pattern](../rules/02-repository-pattern.md)
+-   [CONTRIBUTING.md](../../CONTRIBUTING.md)
+-   [Domain-Driven Design by Eric Evans](https://www.domainlanguage.com/ddd/)
+-   [Laravel Beyond CRUD (Spatie)](https://laravel-beyond-crud.com/)

--- a/.development-context/ADRs/003-laravel-sanctum-authentication.md
+++ b/.development-context/ADRs/003-laravel-sanctum-authentication.md
@@ -1,0 +1,338 @@
+# ADR-003: Laravel Sanctum for API Authentication
+
+## Status
+
+Accepted (2024-10-14)
+
+## Context
+
+Junction Bank requires secure API authentication for:
+
+-   Next.js frontend application
+-   Potential mobile apps in future
+-   Third-party API integrations
+-   Multi-device access per user
+
+The system currently uses Clerk for authentication, but we're migrating to a Laravel-native solution to:
+
+1. Reduce external dependencies
+2. Improve control over auth flow
+3. Simplify deployment
+4. Reduce costs
+5. Enable self-hosting
+
+### Requirements
+
+-   Token-based authentication for SPA/API
+-   Support for multiple devices per user
+-   Token expiration and refresh
+-   Secure token storage
+-   Role-based authorization
+-   API rate limiting
+-   CSRF protection
+-   Simple integration with Laravel
+
+### Constraints
+
+-   Must work with Next.js frontend
+-   Must support future mobile apps
+-   Should integrate with existing Laravel stack
+-   Must be production-ready and well-maintained
+-   Should not require complex infrastructure
+
+## Decision
+
+We will use **Laravel Sanctum** for API authentication.
+
+### Implementation
+
+**Token-based authentication:**
+
+-   Bearer tokens for API requests
+-   Separate tokens per device/session
+-   Token abilities/scopes support
+-   Personal access tokens
+
+**Architecture:**
+
+```mermaid
+graph LR
+    Client[Next.js Client] -->|POST /api/auth/login| API[Laravel API]
+    API -->|Return Bearer Token| Client
+    Client -->|API Requests + Bearer Token| API
+    API -->|Verify Token| Sanctum[Sanctum]
+    Sanctum -->|Authenticate| API
+```
+
+**Configuration:**
+
+```php
+// config/sanctum.php
+'expiration' => 60 * 24 * 7, // 7 days
+'middleware' => [
+    'verify_csrf_token' => false, // SPA uses tokens
+    'encrypt_cookies' => false,
+],
+```
+
+**Authentication Flow:**
+
+1. User registers/logs in with email/password
+2. Server validates credentials
+3. Server generates Sanctum token
+4. Client stores token (httpOnly cookie or localStorage)
+5. Client includes token in Authorization header
+6. Server validates token on each request
+
+**Endpoints:**
+
+-   `POST /api/auth/register` - Register new user
+-   `POST /api/auth/login` - Login and receive token
+-   `POST /api/auth/logout` - Revoke current token
+-   `GET /api/auth/me` - Get current user
+
+**Middleware:**
+
+```php
+Route::middleware('auth:sanctum')->group(function () {
+    // Protected routes
+});
+```
+
+## Consequences
+
+### Positive
+
+-   **Laravel Native:** First-party package, well-maintained and documented
+-   **Simple:** Minimal configuration, straightforward implementation
+-   **Flexible:** Works with SPA, mobile, and API clients
+-   **Secure:** Industry-standard token-based auth
+-   **Multiple Tokens:** Per-device tokens with independent expiration
+-   **Token Abilities:** Granular permissions per token
+-   **Rate Limiting:** Built-in throttling support
+-   **No Complex Infrastructure:** No OAuth server or JWT signing required
+-   **Performance:** Fast token verification
+-   **Cost:** Free, no external services
+-   **Control:** Full ownership of auth system
+-   **Privacy:** User data stays on our servers
+
+### Negative
+
+-   **Token Storage:** Client responsible for secure token storage
+-   **Token Expiration:** Requires refresh token logic for long-lived sessions
+-   **Revocation:** Requires database query to verify token not revoked
+-   **No Built-in SSO:** Would need separate implementation
+-   **Stateful:** Tokens stored in database (vs stateless JWT)
+
+### Neutral
+
+-   **Database Dependency:** Token verification requires DB lookup (mitigated by caching)
+-   **Migration Required:** Must migrate from Clerk authentication
+-   **Password Management:** Must implement password reset flow
+
+## Alternatives Considered
+
+### Alternative 1: Laravel Passport (OAuth2)
+
+**Description:** Full OAuth2 server implementation
+
+**Pros:**
+
+-   Industry standard OAuth2
+-   Supports multiple grant types
+-   Built for third-party integrations
+-   Access + refresh tokens
+-   Scopes and abilities
+
+**Cons:**
+
+-   Overkill for SPA authentication
+-   More complex setup and configuration
+-   Heavier infrastructure
+-   Longer tokens
+-   More database tables
+-   Not recommended by Laravel for simple API auth
+
+**Why not chosen:** Sanctum is Laravel's recommendation for SPA/API auth. Passport is for OAuth server needs.
+
+### Alternative 2: JWT with tymon/jwt-auth
+
+**Description:** JSON Web Tokens with third-party package
+
+**Pros:**
+
+-   Stateless (no database lookup)
+-   Self-contained tokens
+-   Standard JWT format
+-   Works across services
+
+**Cons:**
+
+-   Third-party package (less maintained)
+-   Cannot revoke tokens before expiration
+-   Token size larger
+-   Secret key management critical
+-   No per-device token tracking
+-   Rotation complexity
+
+**Why not chosen:** Sanctum provides better token management and is officially supported. Stateless tokens make revocation difficult.
+
+### Alternative 3: Keep Clerk
+
+**Description:** Continue using Clerk authentication service
+
+**Pros:**
+
+-   Already implemented
+-   No migration needed
+-   External service handles auth
+-   Built-in UI components
+-   Social login built-in
+
+**Cons:**
+
+-   External dependency
+-   Cost scales with users
+-   Less control over auth flow
+-   Requires internet connectivity
+-   Cannot self-host
+-   Adds complexity to deployment
+-   User data on external service
+
+**Why not chosen:** Moving to Laravel-native auth reduces dependencies and costs, improves control.
+
+### Alternative 4: Session-Based Auth
+
+**Description:** Traditional Laravel session authentication
+
+**Pros:**
+
+-   Simple Laravel default
+-   CSRF protection built-in
+-   Well understood
+-   No token management
+
+**Cons:**
+
+-   Not suitable for API/SPA
+-   Requires cookies
+-   CORS complications
+-   Not mobile-friendly
+-   Doesn't scale horizontally easily
+-   State management complexity
+
+**Why not chosen:** Not appropriate for API-first architecture with separate frontend.
+
+### Alternative 5: Firebase Authentication
+
+**Description:** Google Firebase Auth service
+
+**Pros:**
+
+-   Managed service
+-   Social login built-in
+-   Mobile SDKs
+-   Real-time features
+
+**Cons:**
+
+-   External dependency
+-   Vendor lock-in
+-   Cost at scale
+-   Requires Firebase account
+-   Less Laravel integration
+-   User data external
+
+**Why not chosen:** Similar issues to Clerk - external dependency and lack of control.
+
+## Implementation Strategy
+
+### Phase 1: Setup Sanctum
+
+-   Install Sanctum package
+-   Run migrations
+-   Configure sanctum.php
+-   Setup middleware
+
+### Phase 2: Auth Endpoints
+
+-   Create AuthController
+-   Implement register/login/logout
+-   Add validation
+-   Create tests
+
+### Phase 3: Migrate from Clerk
+
+-   Create user migration
+-   Map Clerk users to Laravel users
+-   Update frontend to use new auth
+-   Remove Clerk dependency
+
+### Phase 4: Enhanced Features
+
+-   Add password reset
+-   Implement email verification
+-   Add two-factor authentication (optional)
+-   Setup token expiration alerts
+
+## Security Considerations
+
+**Token Storage (Client):**
+
+-   Use httpOnly cookies when possible
+-   If localStorage, XSS protections critical
+-   Never log tokens
+-   Rotate tokens periodically
+
+**Token Security (Server):**
+
+-   Long random token generation
+-   Hashed in database
+-   HTTPS only in production
+-   Rate limiting on auth endpoints
+-   Brute force protection
+
+**Password Security:**
+
+-   Bcrypt hashing
+-   Minimum length requirements
+-   Common password blacklist
+-   Password confirmation for sensitive actions
+
+## Migration from Clerk
+
+```php
+// Migration strategy
+1. Install Sanctum
+2. Create auth endpoints
+3. Dual authentication (Clerk + Sanctum) during migration
+4. Migrate users from Clerk to Laravel
+5. Update frontend to new endpoints
+6. Remove Clerk when complete
+```
+
+## Testing Strategy
+
+```php
+// Feature tests
+it('registers a new user', function () { ... });
+it('logs in with valid credentials', function () { ... });
+it('returns token on successful login', function () { ... });
+it('fails with invalid credentials', function () { ... });
+it('logs out and revokes token', function () { ... });
+it('protects routes with auth:sanctum middleware', function () { ... });
+```
+
+## Performance Considerations
+
+-   **Token Verification:** Requires DB lookup - cache heavily
+-   **Redis Caching:** Cache valid tokens to reduce DB queries
+-   **Token Cleanup:** Schedule job to delete expired tokens
+-   **Rate Limiting:** Apply aggressive limits to auth endpoints
+
+## References
+
+-   [Laravel Sanctum Documentation](https://laravel.com/docs/sanctum)
+-   [PRD-006: Security & Authentication Setup](../PRDs/PRD-006-security-authentication-setup.md)
+-   [config/sanctum.php](../../config/sanctum.php)
+-   [app/Models/User.php](../../app/Models/User.php)

--- a/.development-context/ADRs/README.md
+++ b/.development-context/ADRs/README.md
@@ -1,0 +1,293 @@
+# Architecture Decision Records (ADRs)
+
+## Overview
+
+This directory contains Architecture Decision Records documenting significant technical decisions made in Junction Bank development.
+
+## What is an ADR?
+
+An Architecture Decision Record captures a single architectural decision and its context. Each ADR describes:
+
+-   The decision made
+-   Why it was made
+-   What alternatives were considered
+-   What consequences resulted
+
+## ADR Format
+
+```markdown
+# ADR-NNN: Title
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by ADR-XXX
+
+## Context
+
+What is the issue we're addressing? What forces are at play?
+
+## Decision
+
+What did we decide to do?
+
+## Consequences
+
+What becomes easier or harder as a result?
+
+## Alternatives Considered
+
+What other options did we evaluate?
+```
+
+## Current ADRs
+
+### Infrastructure & Architecture
+
+**[ADR-001: Docker + Laravel Infrastructure](001-docker-laravel-infrastructure.md)**
+
+-   Status: Accepted
+-   Multi-environment Docker setup with PHP 8.3, PostgreSQL 16, Redis 7, Caddy
+-   Separate compose files for dev/prod/test environments
+-   Justfile for command management
+
+### Domain Design
+
+**[ADR-094: Transaction Type System](94-transaction-type-system.md)**
+
+-   Status: Accepted
+-   Explicit Income/Expense types vs. derived from category
+-   Type field on Transaction model
+-   Supports cross-category transaction flexibility
+
+**[ADR: Controller Control Flow](control%20flow%20through%20controllers.md)**
+
+-   Status: Accepted
+-   Controllers delegate to Actions
+-   Actions contain business logic
+-   Repository pattern for data access
+-   DTOs for data transfer between layers
+
+**[ADR: Resource Drawer Pattern](resource-drawer-usage.md)**
+
+-   Status: Accepted
+-   Standardized UI pattern for creating/editing resources
+-   Consistent user experience across domains
+-   Reusable components with domain-specific content
+
+## Creating a New ADR
+
+### 1. Choose Next Number
+
+Find the next available ADR number:
+
+```bash
+ls -1 .development-context/ADRs/*.md | tail -1
+```
+
+### 2. Create File
+
+```bash
+touch .development-context/ADRs/NNN-title-of-decision.md
+```
+
+### 3. Use Template
+
+```markdown
+# ADR-NNN: Title of Decision
+
+## Status
+
+Proposed
+
+## Context
+
+Describe the problem or opportunity.
+
+What is the current situation?
+What constraints exist?
+What requirements must be met?
+
+## Decision
+
+We will [decision statement].
+
+[Explain the decision in detail]
+
+## Consequences
+
+### Positive
+
+-   Benefit 1
+-   Benefit 2
+
+### Negative
+
+-   Tradeoff 1
+-   Tradeoff 2
+
+### Neutral
+
+-   Changes to existing systems
+-   New dependencies
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+**Description:** ...
+**Pros:** ...
+**Cons:** ...
+**Why not chosen:** ...
+
+### Alternative 2: [Name]
+
+**Description:** ...
+**Pros:** ...
+**Cons:** ...
+**Why not chosen:** ...
+
+## References
+
+-   [Related documentation]
+-   [External resources]
+-   [Related ADRs]
+```
+
+### 4. Propose and Discuss
+
+1. Create ADR with status "Proposed"
+2. Share with team for review
+3. Discuss and refine
+4. Update status to "Accepted" when consensus reached
+
+### 5. Update This README
+
+Add the new ADR to the appropriate section above.
+
+## ADR Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Proposed
+    Proposed --> Accepted: Consensus reached
+    Proposed --> Rejected: Alternative chosen
+    Accepted --> Deprecated: No longer recommended
+    Accepted --> Superseded: Replaced by new ADR
+    Rejected --> [*]
+    Deprecated --> [*]
+    Superseded --> [*]
+```
+
+**Status Definitions:**
+
+-   **Proposed:** Under discussion, not yet approved
+-   **Accepted:** Approved and active
+-   **Deprecated:** No longer recommended but still in use
+-   **Superseded:** Replaced by a newer ADR
+-   **Rejected:** Considered but not adopted
+
+## When to Create an ADR
+
+Create an ADR when:
+
+-   Making significant architectural decisions
+-   Choosing between multiple viable approaches
+-   Establishing cross-cutting concerns (auth, caching, etc.)
+-   Adopting new technologies or patterns
+-   Changing existing architectural decisions
+
+Do NOT create an ADR for:
+
+-   Minor implementation details
+-   Obvious choices with no alternatives
+-   Temporary workarounds
+-   Bug fixes
+
+## Best Practices
+
+### Be Concise
+
+Focus on the decision and its rationale. Avoid implementation details.
+
+### Be Objective
+
+Present facts and tradeoffs neutrally. Let the decision speak for itself.
+
+### Document Alternatives
+
+Show what was considered. Future readers need context.
+
+### Update as Needed
+
+If circumstances change, update status:
+
+-   Mark as "Deprecated" if no longer recommended
+-   Create new ADR and mark old as "Superseded"
+
+### Link Related ADRs
+
+Reference other ADRs that relate to the decision.
+
+### Date Stamps
+
+Include dates for status changes:
+
+```markdown
+## Status
+
+Accepted (2024-01-15)
+Superseded by ADR-123 (2024-06-20)
+```
+
+## Reviewing ADRs
+
+### For Reviewers
+
+Ask:
+
+-   Is the problem clearly stated?
+-   Are alternatives adequately considered?
+-   Are consequences realistic?
+-   Is the decision justified?
+-   Will this age well?
+
+### For Authors
+
+Ensure:
+
+-   Context explains the "why"
+-   Decision is clear and actionable
+-   Consequences are honest about tradeoffs
+-   Alternatives show due diligence
+
+## ADR Tools
+
+### Search ADRs
+
+```bash
+grep -r "keyword" .development-context/ADRs/
+```
+
+### List by Status
+
+```bash
+grep -l "Status: Accepted" .development-context/ADRs/*.md
+```
+
+### Find Superseded ADRs
+
+```bash
+grep -l "Superseded" .development-context/ADRs/*.md
+```
+
+## Related Documentation
+
+-   [Development Rules](../rules/) - Coding standards and patterns
+-   [PRDs](../PRDs/) - Product requirements
+-   [CONTRIBUTING.md](../../CONTRIBUTING.md) - Development workflow
+
+## References
+
+-   [Architecture Decision Records (Michael Nygard)](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+-   [ADR GitHub Organization](https://adr.github.io/)
+-   [Documenting Architecture Decisions](https://www.thoughtworks.com/radar/techniques/lightweight-architecture-decision-records)

--- a/.development-context/PRDs/PRD-008-documentation-developer-experience.md
+++ b/.development-context/PRDs/PRD-008-documentation-developer-experience.md
@@ -6,26 +6,25 @@
 
 ## Requirements
 
-- Comprehensive setup documentation
-- Developer onboarding guide
-- API documentation
-- Architecture decision records
-- Troubleshooting guides
+-   Comprehensive setup documentation
+-   Developer onboarding guide
+-   API documentation
+-   Architecture decision records
+-   Troubleshooting guides
 
 ## Acceptance Criteria
 
-- [ ] README.md with setup instructions
-- [ ] CONTRIBUTING.md with development workflow
-- [ ] API documentation with examples
-- [ ] Architecture decision records in `.development-context/ADRs/`
-- [ ] Docker setup troubleshooting guide
-- [ ] Local development best practices
+-   [x] README.md with setup instructions
+-   [x] CONTRIBUTING.md with development workflow
+-   [x] API documentation with examples
+-   [x] Architecture decision records in `.development-context/ADRs/`
+-   [x] Docker setup troubleshooting guide
+-   [x] Local development best practices
 
 ## Technical Specifications
 
-- Markdown documentation
-- OpenAPI/Swagger API documentation
-- Architecture diagrams
-- Code style guidelines
-- Git workflow documentation
-
+-   Markdown documentation
+-   OpenAPI/Swagger API documentation
+-   Architecture diagrams
+-   Code style guidelines
+-   Git workflow documentation

--- a/.development-context/tickets/categories/README.md
+++ b/.development-context/tickets/categories/README.md
@@ -1,0 +1,57 @@
+# Categories Domain - Development Tickets
+
+**Total Estimate:** 4-5 days across 24 tickets
+
+## Overview
+
+This directory contains all development tickets for implementing the Categories domain in the Junction Bank application.
+
+## Ticket Organization
+
+### Foundation & Infrastructure (Days 1-2)
+
+-   TICKET-001: Database Schema & Migration
+-   TICKET-002: Category Eloquent Model
+-   TICKET-003: Category Entity (Domain)
+-   TICKET-004: Repository Interface
+-   TICKET-005: Redis Cache Configuration
+
+### Domain Layer (Days 2-3)
+
+-   TICKET-006: Category Repository Implementation
+-   TICKET-007: Category Mapper
+-   TICKET-008: IndexCategories Use Case
+-   TICKET-009: ShowCategory Use Case
+-   TICKET-010: StoreCategory Use Case
+-   TICKET-011: UpdateCategory Use Case
+-   TICKET-012: DeleteCategory Use Case
+
+### API Layer (Days 3-4)
+
+-   TICKET-013: Form Request Validation
+-   TICKET-014: Category Controller - List & Show
+-   TICKET-015: Category Controller - Create
+-   TICKET-016: Category Controller - Update & Delete
+-   TICKET-017: API Routes Configuration
+-   TICKET-018: Service Provider Bindings
+
+### Testing & Quality (Day 4-5)
+
+-   TICKET-019: Integration Tests - CRUD Flow
+-   TICKET-020: Integration Tests - Cache Behavior
+-   TICKET-021: API Documentation
+-   TICKET-022: Performance Testing
+-   TICKET-023: Error Handling & Logging
+-   TICKET-024: Code Review & Cleanup
+
+## Usage
+
+Each ticket file contains:
+
+-   Estimate
+-   Priority level
+-   Dependencies
+-   Task list
+-   Acceptance criteria
+
+Start with Foundation tickets and progress sequentially through each phase.

--- a/.development-context/tickets/categories/TICKET-001.md
+++ b/.development-context/tickets/categories/TICKET-001.md
@@ -1,0 +1,85 @@
+# TICKET-001: Database Schema & Migration
+
+**Estimate:** 2-3 hours  
+**Priority:** Critical  
+**Dependencies:** None  
+**PRD Reference:** Lines 356-402
+
+## Overview
+
+Create the foundational database schema for the Categories domain. This migration establishes the `categories` table with all required columns, constraints, and indexes as specified in the PRD.
+
+## Technical Specifications
+
+### Table Schema
+
+```sql
+CREATE TABLE categories (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    type ENUM('income', 'expense') NOT NULL,
+    notes TEXT NULL,
+    is_recurring BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY unique_name (name),
+    INDEX idx_type (type),
+    INDEX idx_is_recurring (is_recurring)
+);
+```
+
+### Column Specifications
+
+| Column       | Type                      | Null | Default           | Purpose                    |
+| ------------ | ------------------------- | ---- | ----------------- | -------------------------- |
+| id           | BIGINT                    | NO   | AUTO_INCREMENT    | Primary key                |
+| name         | VARCHAR(255)              | NO   | -                 | Category name (unique)     |
+| type         | ENUM('income', 'expense') | NO   | -                 | Category type              |
+| notes        | TEXT                      | YES  | NULL              | Optional description       |
+| is_recurring | BOOLEAN                   | NO   | FALSE             | Recurring transaction flag |
+| created_at   | TIMESTAMP                 | NO   | CURRENT_TIMESTAMP | Creation timestamp         |
+| updated_at   | TIMESTAMP                 | NO   | CURRENT_TIMESTAMP | Update timestamp           |
+
+### Indexes Required
+
+1. **PRIMARY KEY** on `id` - Fast lookups by ID
+2. **UNIQUE KEY** on `name` - Enforce uniqueness constraint
+3. **INDEX** on `type` - Optimize filtering by income/expense
+4. **INDEX** on `is_recurring` - Optimize recurring transaction queries
+
+## Implementation Tasks
+
+1. Create migration file: `php artisan make:migration create_categories_table`
+2. Define `up()` method with table schema
+3. Define `down()` method for rollback
+4. Test migration execution
+5. Test migration rollback
+
+## Acceptance Criteria
+
+-   [ ] Migration file created using artisan command
+-   [ ] All 7 columns present with correct types
+-   [ ] Unique constraint on `name` enforced
+-   [ ] Indexes on `type` and `is_recurring` created
+-   [ ] Primary key auto-increments
+-   [ ] `up()` and `down()` methods implemented
+-   [ ] Migration runs successfully: `php artisan migrate`
+-   [ ] Migration rollback works: `php artisan migrate:rollback`
+-   [ ] Schema matches PRD specification exactly
+-   [ ] All test cases pass
+
+## Validation Checklist
+
+-   [ ] Run: `php artisan migrate` (no errors)
+-   [ ] Verify table exists in database
+-   [ ] Verify unique constraint: attempt duplicate insert (should fail)
+-   [ ] Verify enum constraint: attempt invalid type (should fail)
+-   [ ] Run: `php artisan migrate:rollback` (table removed)
+-   [ ] Run: `php artisan migrate` again (idempotent)
+
+## Related PRD Sections
+
+-   **Data Model:** Lines 356-402
+-   **Business Rules:** Lines 528-547
+-   **Validation Rules:** Lines 550-590

--- a/.development-context/tickets/categories/TICKET-002.md
+++ b/.development-context/tickets/categories/TICKET-002.md
@@ -1,0 +1,108 @@
+# TICKET-002: Category Eloquent Model
+
+**Estimate:** 2-3 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-001  
+**PRD Reference:** Lines 356-402, 394-397
+
+## Overview
+
+Create the Eloquent ORM model that maps to the `categories` database table. This model serves as the infrastructure layer's data access object and will be used by the repository implementation.
+
+## Technical Specifications
+
+### Model Location
+
+`app/Models/Category.php`
+
+### Model Configuration
+
+```php
+class Category extends Model
+{
+    protected $table = 'categories';
+
+    protected $fillable = [
+        'name',
+        'type',
+        'notes',
+        'is_recurring'
+    ];
+
+    protected $casts = [
+        'is_recurring' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime'
+    ];
+
+    // Relationships (stubs for future implementation)
+    public function transactions() {
+        // Will be implemented in Transactions domain
+    }
+
+    public function recurringTransactions() {
+        // Will be implemented in RecurringTransactions domain
+    }
+}
+```
+
+### Fillable Attributes
+
+-   `name` - Category name (string)
+-   `type` - Category type (string enum: 'income', 'expense')
+-   `notes` - Optional description (string|null)
+-   `is_recurring` - Recurring flag (boolean)
+
+### Type Casting
+
+-   `is_recurring` → boolean (stored as tinyint in DB)
+-   `created_at` → datetime object
+-   `updated_at` → datetime object
+
+### Relationships (Future)
+
+-   **hasMany** `transactions` - Categories can have many transactions
+-   **hasMany** `recurringTransactions` - Categories can have many recurring transactions
+
+## Implementation Tasks
+
+1. Create model: `php artisan make:model Category`
+2. Configure table name (if needed)
+3. Set fillable attributes
+4. Add type casts
+5. Define relationship method stubs
+6. Add PHPDoc annotations
+7. Write model tests
+
+## Acceptance Criteria
+
+-   [ ] Model file created at `app/Models/Category.php`
+-   [ ] All fillable attributes defined
+-   [ ] Type casting configured for boolean and dates
+-   [ ] Relationship method stubs present
+-   [ ] PHPDoc blocks on all methods
+-   [ ] Model can be instantiated successfully
+-   [ ] Mass assignment works for fillable fields
+-   [ ] Type casting works correctly
+-   [ ] All test cases pass
+
+## Validation Checklist
+
+-   [ ] Create test category in tinker
+-   [ ] Verify boolean casting: `$category->is_recurring === true`
+-   [ ] Verify datetime casting: `$category->created_at instanceof Carbon`
+-   [ ] Verify mass assignment: `Category::create([...])`
+-   [ ] Run model tests: `php artisan test --filter=CategoryModelTest`
+
+## Notes
+
+-   Do NOT implement actual relationship logic yet (transactions table doesn't exist)
+-   Keep relationship methods as empty stubs with TODO comments
+-   Focus on basic model configuration and attributes
+-   Ensure model aligns with migration from TICKET-001
+
+## Related PRD Sections
+
+-   **Data Model:** Lines 356-402
+-   **Relationships:** Lines 394-397
+-   **Layer Architecture - Infrastructure:** Lines 430-439

--- a/.development-context/tickets/categories/TICKET-003.md
+++ b/.development-context/tickets/categories/TICKET-003.md
@@ -1,0 +1,245 @@
+# TICKET-003: Category Entity (Domain)
+
+**Estimate:** 3-4 hours  
+**Priority:** Critical  
+**Dependencies:** None  
+**PRD Reference:** Lines 145-165, 553-575
+
+## Overview
+
+Create the core Category domain entity that encapsulates business rules and validation logic. This is the heart of the domain layer and enforces all business constraints independent of infrastructure.
+
+## Technical Specifications
+
+### Entity Location
+
+`app/Domains/Categories/Entities/Category.php`
+
+### Entity Structure
+
+```php
+namespace App\Domains\Categories\Entities;
+
+class Category
+{
+    private ?int $id;
+    private string $name;
+    private string $type; // 'income' | 'expense'
+    private ?string $notes;
+    private bool $isRecurring;
+    private ?\DateTimeInterface $createdAt;
+
+    public function __construct(
+        string $name,
+        string $type,
+        ?string $notes = null,
+        bool $isRecurring = false,
+        ?int $id = null,
+        ?\DateTimeInterface $createdAt = null
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->notes = $notes;
+        $this->isRecurring = $isRecurring;
+        $this->id = $id;
+        $this->createdAt = $createdAt;
+
+        $this->validate();
+    }
+
+    private function validate(): void {
+        // Validation logic from PRD lines 553-575
+    }
+
+    // Getters, setters, business methods
+}
+```
+
+### Validation Rules (PRD Lines 553-575)
+
+#### Name Validation
+
+-   **Required:** Cannot be empty or null
+-   **Max Length:** 255 characters
+-   **Exception:** `CategoryNameEmptyException` if empty
+-   **Exception:** `InvalidCategoryNameException` if > 255 chars
+
+#### Type Validation
+
+-   **Required:** Must be 'income' or 'expense'
+-   **Exception:** `InvalidCategoryTypeException` if not in ['income', 'expense']
+
+#### Notes Validation
+
+-   **Optional:** Can be null
+-   **Max Length:** 1000 characters if provided
+-   **Exception:** `InvalidCategoryNotesException` if > 1000 chars
+
+### Exception Classes
+
+Create in `app/Domains/Categories/Exceptions/`
+
+```php
+// Base exception
+abstract class CategoryException extends \Exception {}
+
+// Specific exceptions
+class CategoryNameEmptyException extends CategoryException {}
+class InvalidCategoryNameException extends CategoryException {}
+class InvalidCategoryTypeException extends CategoryException {}
+class InvalidCategoryNotesException extends CategoryException {}
+class CategoryNotFoundException extends CategoryException {}
+class CategoryAlreadyExistsException extends CategoryException {}
+class CategoryHasTransactionsException extends CategoryException {}
+```
+
+### Business Methods
+
+```php
+public function changeName(string $newName): void
+public function changeType(string $newType): void
+public function updateNotes(?string $newNotes): void
+public function markAsRecurring(): void
+public function markAsNonRecurring(): void
+```
+
+## Implementation Tasks
+
+1. Create entity class with private properties
+2. Implement constructor with validation
+3. Implement `validate()` method with all rules
+4. Create all exception classes
+5. Add getter methods
+6. Add business methods for state changes
+7. Add PHPDoc annotations
+8. Write comprehensive unit tests
+
+## Test Cases
+
+### Name Validation Tests
+
+```php
+describe('Category Entity Name Validation', function () {
+    it('throws exception when name is empty')
+    it('throws exception when name is null')
+    it('throws exception when name exceeds 255 characters')
+    it('accepts valid name')
+    it('accepts name at exactly 255 characters')
+    it('validates new name on changeName')
+});
+```
+
+### Type Validation Tests
+
+```php
+describe('Category Entity Type Validation', function () {
+    it('accepts income type')
+    it('accepts expense type')
+    it('throws exception for invalid type')
+    it('throws exception for null type')
+    it('throws exception for empty type')
+    it('throws exception for uppercase INCOME')
+    it('validates new type on changeType')
+});
+```
+
+### Notes Validation Tests
+
+```php
+describe('Category Entity Notes Validation', function () {
+    it('accepts null notes')
+    it('accepts empty string notes')
+    it('accepts valid notes')
+    it('throws exception when notes exceed 1000 characters')
+    it('accepts notes at exactly 1000 characters')
+    it('validates new notes on updateNotes')
+});
+```
+
+### Constructor Tests
+
+```php
+describe('Category Entity Constructor', function () {
+    it('creates entity with all fields')
+    it('creates entity with minimal fields')
+    it('validates on construction')
+    it('sets default values correctly')
+    it('preserves id when provided')
+    it('preserves createdAt when provided')
+});
+```
+
+### Business Method Tests
+
+```php
+describe('Category Entity Business Methods', function () {
+    it('updates name via changeName and validates')
+    it('updates type via changeType and validates')
+    it('updates notes via updateNotes and validates')
+    it('sets flag to true via markAsRecurring')
+    it('sets flag to false via markAsNonRecurring')
+});
+```
+
+### Immutability Tests
+
+```php
+describe('Category Entity Immutability', function () {
+    it('has properties that are not publicly accessible')
+    it('allows changes only via methods')
+    it('returns values correctly via getters')
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('Category Entity Edge Cases', function () {
+    it('handles unicode characters in name')
+    it('handles special characters in notes')
+    it('rejects whitespace-only name')
+    it('trims whitespace from name')
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] Entity class created at correct location
+-   [ ] All 7 exception classes created
+-   [ ] Name validation implemented per PRD
+-   [ ] Type validation implemented per PRD
+-   [ ] Notes validation implemented per PRD
+-   [ ] Constructor validates on instantiation
+-   [ ] All getters implemented
+-   [ ] All business methods implemented
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 30+ test cases pass
+-   [ ] No infrastructure dependencies (pure domain logic)
+
+## Validation Checklist
+
+-   [ ] Entity instantiates with valid data
+-   [ ] Empty name throws `CategoryNameEmptyException`
+-   [ ] Long name (256 chars) throws `InvalidCategoryNameException`
+-   [ ] Invalid type throws `InvalidCategoryTypeException`
+-   [ ] Long notes (1001 chars) throws `InvalidCategoryNotesException`
+-   [ ] Run tests: `php artisan test --filter=CategoryEntityTest`
+-   [ ] Code coverage: `php artisan test --coverage --min=100`
+
+## Notes
+
+-   This is pure domain logic with NO Laravel dependencies
+-   No database, no Eloquent, no HTTP - just business rules
+-   Entity should be framework-agnostic
+-   Focus on business invariants and rules
+-   Exceptions provide clear error messages
+-   All validation happens in constructor and business methods
+
+## Related PRD Sections
+
+-   **Domain Model - Entities:** Lines 145-165
+-   **Business Rules:** Lines 528-547
+-   **Validation Rules - Entity Validation:** Lines 553-575
+-   **Exception Hierarchy:** Lines 595-603
+-   **Layer Architecture - Domain Layer:** Lines 408-417

--- a/.development-context/tickets/categories/TICKET-004.md
+++ b/.development-context/tickets/categories/TICKET-004.md
@@ -1,0 +1,234 @@
+# TICKET-004: Repository Interface
+
+**Estimate:** 1-2 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-003  
+**PRD Reference:** Lines 412-416, 430-439
+
+## Overview
+
+Define the repository interface contract that abstracts data persistence operations for the Category domain. This interface is part of the domain layer and will be implemented in the infrastructure layer.
+
+## Technical Specifications
+
+### Interface Location
+
+`app/Domains/Categories/Repositories/ICategoryRepository.php`
+
+### Interface Definition
+
+```php
+namespace App\Domains\Categories\Repositories;
+
+use App\Domains\Categories\Entities\Category;
+use App\Domains\Categories\Exceptions\CategoryNotFoundException;
+use App\Domains\Categories\Exceptions\CategoryAlreadyExistsException;
+
+/**
+ * Category Repository Interface
+ *
+ * Defines the contract for category data persistence operations.
+ * Implementations should handle database operations and caching.
+ */
+interface ICategoryRepository
+{
+    /**
+     * Find all categories with optional filtering and pagination
+     *
+     * @param int $page Page number (1-indexed)
+     * @param int $limit Items per page
+     * @param string|null $type Filter by type ('income' or 'expense')
+     * @return array{data: Category[], pagination: array}
+     */
+    public function findAll(int $page = 1, int $limit = 20, ?string $type = null): array;
+
+    /**
+     * Find category by ID
+     *
+     * @param int $id Category ID
+     * @return Category
+     * @throws CategoryNotFoundException
+     */
+    public function findById(int $id): Category;
+
+    /**
+     * Create a new category
+     *
+     * @param Category $category Category entity to persist
+     * @return Category Persisted category with ID
+     * @throws CategoryAlreadyExistsException If name already exists
+     */
+    public function create(Category $category): Category;
+
+    /**
+     * Update existing category
+     *
+     * @param Category $category Category entity with changes
+     * @return Category Updated category
+     * @throws CategoryNotFoundException
+     * @throws CategoryAlreadyExistsException If new name conflicts
+     */
+    public function update(Category $category): Category;
+
+    /**
+     * Delete category by ID
+     *
+     * @param int $id Category ID
+     * @return void
+     * @throws CategoryNotFoundException
+     * @throws CategoryHasTransactionsException If has dependencies
+     */
+    public function delete(int $id): void;
+
+    /**
+     * Check if category name already exists
+     *
+     * @param string $name Category name to check
+     * @param int|null $excludeId ID to exclude from check (for updates)
+     * @return bool
+     */
+    public function existsByName(string $name, ?int $excludeId = null): bool;
+
+    /**
+     * Check if category has associated transactions
+     *
+     * @param int $id Category ID
+     * @return bool
+     */
+    public function hasTransactions(int $id): bool;
+
+    /**
+     * Check if category has associated recurring transactions
+     *
+     * @param int $id Category ID
+     * @return bool
+     */
+    public function hasRecurringTransactions(int $id): bool;
+}
+```
+
+### Method Specifications
+
+#### findAll()
+
+-   **Purpose:** Retrieve paginated list of categories
+-   **Parameters:** page (int), limit (int), type (string|null)
+-   **Returns:** Array with 'data' (Category[]) and 'pagination' metadata
+-   **Cache Strategy:** Cache by page/limit/type combination
+
+#### findById()
+
+-   **Purpose:** Retrieve single category by ID
+-   **Parameters:** id (int)
+-   **Returns:** Category entity
+-   **Throws:** CategoryNotFoundException if not found
+-   **Cache Strategy:** Cache by ID
+
+#### create()
+
+-   **Purpose:** Persist new category
+-   **Parameters:** Category entity (without ID)
+-   **Returns:** Category entity (with ID assigned)
+-   **Throws:** CategoryAlreadyExistsException if name exists
+-   **Cache Strategy:** Invalidate list caches
+
+#### update()
+
+-   **Purpose:** Update existing category
+-   **Parameters:** Category entity (with ID)
+-   **Returns:** Updated Category entity
+-   **Throws:** CategoryNotFoundException, CategoryAlreadyExistsException
+-   **Cache Strategy:** Invalidate specific category and list caches
+
+#### delete()
+
+-   **Purpose:** Remove category
+-   **Parameters:** id (int)
+-   **Returns:** void
+-   **Throws:** CategoryNotFoundException, CategoryHasTransactionsException
+-   **Cache Strategy:** Invalidate specific category and list caches
+
+#### existsByName()
+
+-   **Purpose:** Check name uniqueness
+-   **Parameters:** name (string), excludeId (int|null)
+-   **Returns:** boolean
+-   **Note:** excludeId used for updates to exclude self
+
+#### hasTransactions()
+
+-   **Purpose:** Check if category has dependent transactions
+-   **Parameters:** id (int)
+-   **Returns:** boolean
+-   **Note:** Used before deletion
+
+#### hasRecurringTransactions()
+
+-   **Purpose:** Check if category has dependent recurring transactions
+-   **Parameters:** id (int)
+-   **Returns:** boolean
+-   **Note:** Used before deletion
+
+## Implementation Tasks
+
+1. Create interface file with namespace
+2. Add all method signatures with type hints
+3. Add comprehensive PHPDoc blocks
+4. Document exceptions
+5. Document return types
+6. Add usage examples in comments
+7. Create interface test (stub implementation test)
+
+## Test Cases
+
+### Interface Tests
+
+```php
+describe('ICategoryRepository Interface', function () {
+    it('defines findAll method with correct signature')
+    it('defines findById method with correct signature')
+    it('defines create method with correct signature')
+    it('defines update method with correct signature')
+    it('defines delete method with correct signature')
+    it('defines existsByName method with correct signature')
+    it('defines hasTransactions method with correct signature')
+    it('defines hasRecurringTransactions method with correct signature')
+    it('can be implemented by concrete classes')
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] Interface created at correct location
+-   [ ] All 8 methods defined with signatures
+-   [ ] Type hints on all parameters
+-   [ ] Return type declarations on all methods
+-   [ ] PHPDoc blocks on all methods
+-   [ ] Exceptions documented in PHPDoc
+-   [ ] Namespace properly defined
+-   [ ] Imports for Category entity and exceptions
+-   [ ] Interface can be type-hinted in constructors
+-   [ ] All test cases pass
+
+## Validation Checklist
+
+-   [ ] Interface file exists and is properly namespaced
+-   [ ] Can be imported: `use App\Domains\Categories\Repositories\ICategoryRepository;`
+-   [ ] Type-hint works: `public function __construct(ICategoryRepository $repo)`
+-   [ ] PHPStan passes with no errors
+-   [ ] IDE recognizes all methods and provides autocomplete
+
+## Notes
+
+-   This is a domain layer interface (not infrastructure)
+-   Keep it framework-agnostic (no Laravel-specific code)
+-   Focus on domain concepts (Category entity), not infrastructure (Eloquent models)
+-   Will be bound to implementation via dependency injection in AppServiceProvider
+-   Implementation will be done in TICKET-006
+
+## Related PRD Sections
+
+-   **Repository Interfaces:** Lines 412-416
+-   **Repository Implementations:** Lines 431-435
+-   **Dependency Injection:** Lines 465-484
+-   **Business Rules:** Lines 528-547

--- a/.development-context/tickets/categories/TICKET-005.md
+++ b/.development-context/tickets/categories/TICKET-005.md
@@ -1,0 +1,249 @@
+# TICKET-005: Redis Cache Configuration
+
+**Estimate:** 1-2 hours  
+**Priority:** High  
+**Dependencies:** None  
+**PRD Reference:** Lines 505-525
+
+## Overview
+
+Configure Redis caching infrastructure for the Categories domain. Create a cache helper class that encapsulates cache key generation and TTL configuration based on the PRD caching strategy.
+
+## Technical Specifications
+
+### Redis Configuration
+
+Ensure Redis is configured in `config/cache.php`:
+
+```php
+'redis' => [
+    'driver' => 'redis',
+    'connection' => 'cache',
+    'lock_connection' => 'default',
+],
+```
+
+### Cache Helper Location
+
+`app/Domains/Categories/Infrastructure/Cache/CategoryCacheKeys.php`
+
+### Cache Helper Implementation
+
+```php
+namespace App\Domains\Categories\Infrastructure\Cache;
+
+/**
+ * Category Cache Keys Helper
+ *
+ * Centralizes cache key generation and TTL management for categories.
+ * Based on PRD caching strategy (lines 507-525).
+ */
+class CategoryCacheKeys
+{
+    // TTL Constants (in seconds)
+    private const LIST_TTL = 3600;        // 1 hour
+    private const SINGLE_TTL = 86400;     // 24 hours
+    private const USER_LIST_TTL = 3600;   // 1 hour
+
+    /**
+     * Generate cache key for paginated category list
+     *
+     * @param int $userId User ID
+     * @param int $page Page number
+     * @param int $limit Items per page
+     * @param string|null $type Filter type
+     * @return string Cache key
+     */
+    public static function list(int $userId, int $page, int $limit, ?string $type = null): string
+    {
+        $typeSegment = $type ? ":{$type}" : '';
+        return "categories:list:{$userId}:{$page}:{$limit}{$typeSegment}";
+    }
+
+    /**
+     * Generate cache key for single category
+     *
+     * @param int $id Category ID
+     * @return string Cache key
+     */
+    public static function single(int $id): string
+    {
+        return "categories:{$id}";
+    }
+
+    /**
+     * Generate cache key for user's all categories
+     *
+     * @param int $userId User ID
+     * @return string Cache key
+     */
+    public static function userCategories(int $userId): string
+    {
+        return "categories:user:{$userId}";
+    }
+
+    /**
+     * Generate pattern for invalidating all user list caches
+     *
+     * @param int $userId User ID
+     * @return string Cache key pattern
+     */
+    public static function listPattern(int $userId): string
+    {
+        return "categories:list:{$userId}:*";
+    }
+
+    /**
+     * Get TTL for list queries
+     *
+     * @return int TTL in seconds
+     */
+    public static function getListTTL(): int
+    {
+        return self::LIST_TTL;
+    }
+
+    /**
+     * Get TTL for single category
+     *
+     * @return int TTL in seconds
+     */
+    public static function getSingleTTL(): int
+    {
+        return self::SINGLE_TTL;
+    }
+
+    /**
+     * Get TTL for user categories
+     *
+     * @return int TTL in seconds
+     */
+    public static function getUserListTTL(): int
+    {
+        return self::USER_LIST_TTL;
+    }
+}
+```
+
+### Cache Key Patterns (PRD Lines 507-525)
+
+```
+categories:list:{user_id}:{page}:{limit}:{type?}   # Paginated lists
+categories:{id}                                     # Single category
+categories:user:{user_id}                          # All user categories
+```
+
+### Cache TTL Strategy
+
+| Cache Type      | TTL      | Reason                                          |
+| --------------- | -------- | ----------------------------------------------- |
+| List queries    | 1 hour   | Frequent changes, balance freshness/performance |
+| Single category | 24 hours | Rarely change once created                      |
+| User categories | 1 hour   | Moderate frequency of changes                   |
+
+### Invalidation Rules
+
+**Triggers:** Create, Update, Delete operations
+
+**Invalidate:**
+
+-   `categories:list:{user_id}:*` - All paginated lists for user
+-   `categories:{id}` - Specific category
+-   `categories:user:{user_id}` - User's full category list
+
+## Implementation Tasks
+
+1. Verify Redis configuration in `config/cache.php`
+2. Create `CategoryCacheKeys` helper class
+3. Implement cache key generation methods
+4. Implement TTL getter methods
+5. Add PHPDoc documentation
+6. Test Redis connectivity
+7. Write cache key generation tests
+8. Document usage examples
+
+## Test Cases
+
+### Cache Key Generation Tests
+
+```php
+describe('CategoryCacheKeys Helper', function () {
+    it('generates list cache key with all parameters')
+    it('generates list cache key without type filter')
+    it('generates single category cache key')
+    it('generates user categories cache key')
+    it('generates list invalidation pattern')
+    it('returns correct list TTL')
+    it('returns correct single TTL')
+    it('returns correct user list TTL')
+    it('generates unique keys for different pages')
+    it('generates unique keys for different types')
+});
+```
+
+### Redis Connection Tests
+
+```php
+describe('Redis Connection', function () {
+    it('can connect to Redis')
+    it('can set and get cache values')
+    it('respects TTL expiration')
+    it('can delete cache keys')
+    it('can delete by pattern')
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] Redis configured in `config/cache.php`
+-   [ ] CategoryCacheKeys class created
+-   [ ] All cache key methods implemented
+-   [ ] TTL constants match PRD specifications
+-   [ ] TTL getter methods implemented
+-   [ ] Pattern generation for invalidation
+-   [ ] PHPDoc on all methods
+-   [ ] Redis connection test passes
+-   [ ] All cache key generation tests pass
+-   [ ] Usage documentation in class comments
+
+## Validation Checklist
+
+-   [ ] Test Redis connection: `php artisan tinker` → `Cache::put('test', 'value')`
+-   [ ] Verify TTL: `Cache::get('test')` immediately returns value
+-   [ ] Verify cache key format matches PRD patterns
+-   [ ] Run tests: `php artisan test --filter=CategoryCacheTest`
+-   [ ] Generate keys for different scenarios and verify uniqueness
+
+## Usage Example
+
+```php
+// In repository
+use App\Domains\Categories\Infrastructure\Cache\CategoryCacheKeys;
+
+$key = CategoryCacheKeys::list($userId, 1, 20, 'expense');
+$ttl = CategoryCacheKeys::getListTTL();
+
+Cache::remember($key, $ttl, function () {
+    // Fetch from database
+});
+
+// Invalidation
+$pattern = CategoryCacheKeys::listPattern($userId);
+// Delete all matching keys
+```
+
+## Notes
+
+-   Redis must be running and accessible
+-   Cache helper is infrastructure layer (not domain)
+-   Keys are designed to be human-readable for debugging
+-   Pattern matching used for bulk invalidation
+-   TTL values can be adjusted based on monitoring data
+
+## Related PRD Sections
+
+-   **Caching Strategy:** Lines 505-525
+-   **Cache Keys:** Lines 507-512
+-   **Cache TTL:** Lines 514-518
+-   **Invalidation Rules:** Lines 520-525
+-   **Repository Implementation:** Lines 431-435

--- a/.development-context/tickets/categories/TICKET-006.md
+++ b/.development-context/tickets/categories/TICKET-006.md
@@ -1,0 +1,397 @@
+# TICKET-006: Category Repository Implementation
+
+**Estimate:** 4-5 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-002, TICKET-004, TICKET-005  
+**PRD Reference:** Lines 431-439, 505-525
+
+## Overview
+
+Implement the concrete CategoryRepository class that fulfills the ICategoryRepository contract. This repository handles all data persistence operations using Eloquent ORM, implements Redis caching for performance, and manages cache invalidation.
+
+## Technical Specifications
+
+### Repository Location
+
+`app/Domains/Categories/Infrastructure/Repositories/CategoryRepository.php`
+
+### Repository Structure
+
+```php
+namespace App\Domains\Categories\Infrastructure\Repositories;
+
+use App\Domains\Categories\Entities\Category;
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Exceptions\{
+    CategoryNotFoundException,
+    CategoryAlreadyExistsException,
+    CategoryHasTransactionsException
+};
+use App\Domains\Categories\Infrastructure\Cache\CategoryCacheKeys;
+use App\Domains\Categories\Infrastructure\Mappers\CategoryMapper;
+use App\Models\Category as CategoryModel;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class CategoryRepository implements ICategoryRepository
+{
+    public function __construct(
+        private CategoryMapper $mapper
+    ) {}
+
+    public function findAll(int $page = 1, int $limit = 20, ?string $type = null): array
+    {
+        // Implementation with caching
+    }
+
+    public function findById(int $id): Category
+    {
+        // Implementation with caching
+    }
+
+    public function create(Category $category): Category
+    {
+        // Implementation with cache invalidation
+    }
+
+    public function update(Category $category): Category
+    {
+        // Implementation with cache invalidation
+    }
+
+    public function delete(int $id): void
+    {
+        // Implementation with dependency checks and cache invalidation
+    }
+
+    public function existsByName(string $name, ?int $excludeId = null): bool
+    {
+        // Implementation
+    }
+
+    public function hasTransactions(int $id): bool
+    {
+        // Implementation - returns false for now (no transactions table yet)
+    }
+
+    public function hasRecurringTransactions(int $id): bool
+    {
+        // Implementation - returns false for now
+    }
+
+    private function invalidateCache(int $id, int $userId): void
+    {
+        // Cache invalidation logic
+    }
+}
+```
+
+### Implementation Details
+
+#### findAll() - Paginated List with Caching
+
+```php
+public function findAll(int $page = 1, int $limit = 20, ?string $type = null): array
+{
+    $userId = auth()->id(); // Get from authenticated user
+    $cacheKey = CategoryCacheKeys::list($userId, $page, $limit, $type);
+    $ttl = CategoryCacheKeys::getListTTL();
+
+    return Cache::remember($cacheKey, $ttl, function () use ($page, $limit, $type, $userId) {
+        $query = CategoryModel::where('user_id', $userId);
+
+        if ($type) {
+            $query->where('type', $type);
+        }
+
+        $total = $query->count();
+        $categories = $query
+            ->orderBy('created_at', 'desc')
+            ->skip(($page - 1) * $limit)
+            ->take($limit)
+            ->get();
+
+        return [
+            'data' => $categories->map(fn($model) => $this->mapper->toEntity($model))->toArray(),
+            'pagination' => [
+                'currentPage' => $page,
+                'totalPages' => (int) ceil($total / $limit),
+                'totalItems' => $total,
+                'itemsPerPage' => $limit,
+            ]
+        ];
+    });
+}
+```
+
+#### findById() - Single Category with Caching
+
+```php
+public function findById(int $id): Category
+{
+    $cacheKey = CategoryCacheKeys::single($id);
+    $ttl = CategoryCacheKeys::getSingleTTL();
+
+    $category = Cache::remember($cacheKey, $ttl, function () use ($id) {
+        return CategoryModel::find($id);
+    });
+
+    if (!$category) {
+        throw new CategoryNotFoundException("Category with ID {$id} not found");
+    }
+
+    return $this->mapper->toEntity($category);
+}
+```
+
+#### create() - With Uniqueness Check and Cache Invalidation
+
+```php
+public function create(Category $category): Category
+{
+    if ($this->existsByName($category->getName())) {
+        throw new CategoryAlreadyExistsException(
+            "Category with name '{$category->getName()}' already exists"
+        );
+    }
+
+    $model = $this->mapper->toModel($category);
+    $model->user_id = auth()->id();
+    $model->save();
+
+    $entity = $this->mapper->toEntity($model);
+
+    $this->invalidateCache($model->id, $model->user_id);
+
+    return $entity;
+}
+```
+
+#### update() - With Uniqueness Check and Cache Invalidation
+
+```php
+public function update(Category $category): Category
+{
+    $model = CategoryModel::find($category->getId());
+
+    if (!$model) {
+        throw new CategoryNotFoundException(
+            "Category with ID {$category->getId()} not found"
+        );
+    }
+
+    if ($this->existsByName($category->getName(), $category->getId())) {
+        throw new CategoryAlreadyExistsException(
+            "Category with name '{$category->getName()}' already exists"
+        );
+    }
+
+    $model->name = $category->getName();
+    $model->type = $category->getType();
+    $model->notes = $category->getNotes();
+    $model->is_recurring = $category->isRecurring();
+    $model->save();
+
+    $entity = $this->mapper->toEntity($model);
+
+    $this->invalidateCache($model->id, $model->user_id);
+
+    return $entity;
+}
+```
+
+#### delete() - With Dependency Checks
+
+```php
+public function delete(int $id): void
+{
+    $model = CategoryModel::find($id);
+
+    if (!$model) {
+        throw new CategoryNotFoundException("Category with ID {$id} not found");
+    }
+
+    if ($this->hasTransactions($id)) {
+        throw new CategoryHasTransactionsException(
+            "Cannot delete category with associated transactions"
+        );
+    }
+
+    if ($this->hasRecurringTransactions($id)) {
+        throw new CategoryHasTransactionsException(
+            "Cannot delete category with associated recurring transactions"
+        );
+    }
+
+    $userId = $model->user_id;
+    $model->delete();
+
+    $this->invalidateCache($id, $userId);
+}
+```
+
+#### existsByName() - Uniqueness Check
+
+```php
+public function existsByName(string $name, ?int $excludeId = null): bool
+{
+    $query = CategoryModel::where('user_id', auth()->id())
+        ->where('name', $name);
+
+    if ($excludeId) {
+        $query->where('id', '!=', $excludeId);
+    }
+
+    return $query->exists();
+}
+```
+
+#### Cache Invalidation
+
+```php
+private function invalidateCache(int $id, int $userId): void
+{
+    // Invalidate specific category cache
+    Cache::forget(CategoryCacheKeys::single($id));
+
+    // Invalidate user's category list cache
+    Cache::forget(CategoryCacheKeys::userCategories($userId));
+
+    // Invalidate all paginated list caches for user
+    // Note: In production, consider using cache tags or dedicated invalidation strategy
+    $pattern = CategoryCacheKeys::listPattern($userId);
+    // Implementation depends on cache driver (Redis supports pattern deletion)
+}
+```
+
+## Implementation Tasks
+
+1. Create CategoryRepository class
+2. Inject CategoryMapper dependency
+3. Implement findAll with pagination and caching
+4. Implement findById with caching
+5. Implement create with uniqueness check
+6. Implement update with uniqueness check
+7. Implement delete with dependency checks
+8. Implement existsByName
+9. Implement hasTransactions (stub)
+10. Implement hasRecurringTransactions (stub)
+11. Implement cache invalidation logic
+12. Add comprehensive PHPDoc
+13. Write unit tests for all methods
+14. Write integration tests with database
+15. Write cache behavior tests
+
+## Test Cases
+
+### Repository CRUD Tests
+
+```php
+describe('CategoryRepository CRUD Operations', function () {
+    it('finds all categories with pagination')
+    it('finds all categories filtered by type')
+    it('finds single category by id')
+    it('throws exception when category not found')
+    it('creates new category')
+    it('throws exception when creating duplicate name')
+    it('updates existing category')
+    it('throws exception when updating to duplicate name')
+    it('allows updating category with same name')
+    it('deletes category when no dependencies')
+    it('throws exception when deleting non-existent category')
+    it('throws exception when category has transactions')
+});
+```
+
+### Cache Behavior Tests
+
+```php
+describe('CategoryRepository Caching', function () {
+    it('caches findAll results')
+    it('returns cached data on subsequent calls')
+    it('invalidates list cache on create')
+    it('invalidates list cache on update')
+    it('invalidates list cache on delete')
+    it('caches findById results')
+    it('invalidates specific cache on update')
+    it('invalidates specific cache on delete')
+    it('respects TTL for list cache')
+    it('respects TTL for single category cache')
+});
+```
+
+### Uniqueness Tests
+
+```php
+describe('CategoryRepository Uniqueness', function () {
+    it('detects duplicate names')
+    it('allows same name for different users')
+    it('excludes self when checking uniqueness on update')
+    it('is case sensitive for name comparison')
+});
+```
+
+### Pagination Tests
+
+```php
+describe('CategoryRepository Pagination', function () {
+    it('returns correct page of results')
+    it('calculates total pages correctly')
+    it('returns correct pagination metadata')
+    it('handles empty results')
+    it('respects limit parameter')
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('CategoryRepository User Isolation', function () {
+    it('only returns categories for authenticated user')
+    it('does not find categories from other users')
+    it('scopes uniqueness check to user')
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] Repository class implements ICategoryRepository
+-   [ ] All 8 interface methods implemented
+-   [ ] CategoryMapper injected via constructor
+-   [ ] Redis caching on read operations
+-   [ ] Cache invalidation on write operations
+-   [ ] Uniqueness check before create/update
+-   [ ] Dependency check before delete
+-   [ ] User isolation for all operations
+-   [ ] Pagination logic correct
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All integration tests pass
+-   [ ] All cache tests pass
+
+## Validation Checklist
+
+-   [ ] Create category via repository
+-   [ ] Verify it's cached: check Redis keys
+-   [ ] Fetch same category: verify cache hit
+-   [ ] Update category: verify cache invalidation
+-   [ ] Create duplicate name: verify exception thrown
+-   [ ] Test pagination: create 25 categories, fetch page 2
+-   [ ] Test filtering: create income/expense, filter each
+-   [ ] Run tests: `php artisan test --filter=CategoryRepositoryTest`
+
+## Notes
+
+-   Repository is infrastructure layer, uses Eloquent and Laravel services
+-   hasTransactions() returns false until Transactions domain is implemented
+-   Cache invalidation by pattern may require Redis-specific code
+-   User ID comes from Laravel's auth() helper
+-   Consider implementing soft deletes in future
+-   Mapper handles entity ↔ model transformation (TICKET-007)
+
+## Related PRD Sections
+
+-   **Repository Implementations:** Lines 431-435
+-   **Caching Strategy:** Lines 505-525
+-   **Business Rules:** Lines 528-547
+-   **Error Handling:** Lines 593-623

--- a/.development-context/tickets/categories/TICKET-007.md
+++ b/.development-context/tickets/categories/TICKET-007.md
@@ -1,0 +1,241 @@
+# TICKET-007: Category Mapper
+
+**Estimate:** 2-3 hours  
+**Priority:** High  
+**Dependencies:** TICKET-003, TICKET-006  
+**PRD Reference:** Lines 437-439, 427-428
+
+## Overview
+
+Create the CategoryMapper class that handles transformations between different data representations: Eloquent models, Domain entities, and DTOs. This mapper ensures clean separation between layers and provides consistent data transformation logic.
+
+## Technical Specifications
+
+### Mapper Location
+
+`app/Domains/Categories/Infrastructure/Mappers/CategoryMapper.php`
+
+### Mapper Structure
+
+```php
+namespace App\Domains\Categories\Infrastructure\Mappers;
+
+use App\Domains\Categories\Entities\Category;
+use App\Models\Category as CategoryModel;
+
+class CategoryMapper
+{
+    /**
+     * Convert Eloquent model to Domain entity
+     */
+    public function toEntity(CategoryModel $model): Category
+    {
+        return new Category(
+            name: $model->name,
+            type: $model->type,
+            notes: $model->notes,
+            isRecurring: $model->is_recurring,
+            id: $model->id,
+            createdAt: $model->created_at
+        );
+    }
+
+    /**
+     * Convert Domain entity to Eloquent model
+     * Note: Does not set user_id - caller must set this
+     */
+    public function toModel(Category $entity): CategoryModel
+    {
+        $model = new CategoryModel();
+
+        if ($entity->getId() !== null) {
+            $model->id = $entity->getId();
+            $model->exists = true;
+        }
+
+        $model->name = $entity->getName();
+        $model->type = $entity->getType();
+        $model->notes = $entity->getNotes();
+        $model->is_recurring = $entity->isRecurring();
+
+        return $model;
+    }
+
+    /**
+     * Convert entity to DTO for API response
+     */
+    public function toDTO(Category $entity): array
+    {
+        return [
+            'id' => $entity->getId(),
+            'name' => $entity->getName(),
+            'type' => $entity->getType(),
+            'notes' => $entity->getNotes(),
+            'isRecurring' => $entity->isRecurring(),
+            'createdAt' => $entity->getCreatedAt()?->format('Y-m-d\TH:i:s\Z'),
+        ];
+    }
+
+    /**
+     * Convert multiple entities to DTOs
+     */
+    public function toDTOCollection(array $entities): array
+    {
+        return array_map(fn($entity) => $this->toDTO($entity), $entities);
+    }
+}
+```
+
+### DTO Structure (PRD Lines 427-428)
+
+API Response format matches PRD lines 202-221:
+
+```json
+{
+    "id": 1,
+    "name": "Groceries",
+    "type": "expense",
+    "notes": "Food and household items",
+    "isRecurring": false,
+    "createdAt": "2024-12-19T10:00:00Z"
+}
+```
+
+## Implementation Tasks
+
+1. Create CategoryMapper class
+2. Implement `toEntity()` method
+3. Implement `toModel()` method
+4. Implement `toDTO()` method
+5. Implement `toDTOCollection()` helper
+6. Handle null values correctly
+7. Format dates to ISO 8601
+8. Add comprehensive PHPDoc
+9. Write unit tests for all methods
+
+## Test Cases
+
+### toEntity() Transformation Tests
+
+```php
+describe('CategoryMapper toEntity()', function () {
+    it('converts model to entity with all fields');
+    it('converts model to entity with null notes');
+    it('converts model with id to entity');
+    it('preserves created_at timestamp');
+    it('converts is_recurring boolean correctly');
+    it('handles minimal model data');
+});
+```
+
+### toModel() Transformation Tests
+
+```php
+describe('CategoryMapper toModel()', function () {
+    it('converts entity to new model');
+    it('converts entity with id to existing model');
+    it('converts entity with null notes');
+    it('sets exists flag when id present');
+    it('does not set user_id automatically');
+    it('preserves all entity data');
+    it('handles entity with null id');
+});
+```
+
+### toDTO() Transformation Tests
+
+```php
+describe('CategoryMapper toDTO()', function () {
+    it('converts entity to DTO array');
+    it('formats createdAt as ISO 8601 string');
+    it('includes all required fields');
+    it('handles null notes in DTO');
+    it('handles null createdAt in DTO');
+    it('uses camelCase for field names');
+    it('converts boolean isRecurring correctly');
+});
+```
+
+### toDTOCollection() Tests
+
+```php
+describe('CategoryMapper toDTOCollection()', function () {
+    it('converts array of entities to array of DTOs');
+    it('handles empty array');
+    it('maintains array order');
+    it('applies toDTO transformation to each entity');
+});
+```
+
+### Null Handling Tests
+
+```php
+describe('CategoryMapper Null Handling', function () {
+    it('handles null notes in toEntity');
+    it('handles null notes in toModel');
+    it('handles null notes in toDTO');
+    it('handles null id in toModel');
+    it('handles null createdAt in toDTO');
+});
+```
+
+### Date Formatting Tests
+
+```php
+describe('CategoryMapper Date Formatting', function () {
+    it('formats date as ISO 8601 in toDTO');
+    it('includes timezone in formatted date');
+    it('handles different timezones correctly');
+    it('preserves DateTime object in toEntity');
+    it('returns null when createdAt is null');
+});
+```
+
+### Bidirectional Transformation Tests
+
+```php
+describe('CategoryMapper Bidirectional Transformation', function () {
+    it('maintains data integrity in model->entity->model cycle');
+    it('maintains data integrity in entity->DTO transformation');
+    it('preserves all required fields through transformations');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] CategoryMapper class created at correct location
+-   [ ] `toEntity()` method implemented
+-   [ ] `toModel()` method implemented
+-   [ ] `toDTO()` method implemented
+-   [ ] `toDTOCollection()` helper implemented
+-   [ ] Null values handled correctly in all methods
+-   [ ] Date formatting uses ISO 8601 standard
+-   [ ] DTO uses camelCase field names per PRD
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 25+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create model, convert to entity, verify all fields
+-   [ ] Create entity, convert to model, verify all fields
+-   [ ] Create entity, convert to DTO, verify JSON structure
+-   [ ] Test null notes through all transformations
+-   [ ] Verify date format: `2024-12-19T10:00:00Z`
+-   [ ] Run tests: `php artisan test --filter=CategoryMapperTest`
+
+## Notes
+
+-   Mapper is infrastructure layer component
+-   No business logic - pure data transformation
+-   `toModel()` does NOT set `user_id` - caller responsibility
+-   Date format must match frontend expectations
+-   DTO field names use camelCase per JavaScript conventions
+-   Consider adding validation that entity data is complete
+
+## Related PRD Sections
+
+-   **Mappers:** Lines 437-439
+-   **DTOs:** Lines 427-428
+-   **API Response Format:** Lines 202-221, 250-262
+-   **Date Formatting:** Consistent with API specifications

--- a/.development-context/tickets/categories/TICKET-008.md
+++ b/.development-context/tickets/categories/TICKET-008.md
@@ -1,0 +1,242 @@
+# TICKET-008: IndexCategories Use Case
+
+**Estimate:** 3-4 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-006, TICKET-007  
+**PRD Reference:** Lines 182-228, 420-425
+
+## Overview
+
+Implement the IndexCategoriesService use case that retrieves paginated, filtered lists of categories. This service orchestrates the repository layer and returns properly formatted DTOs for the API layer. Supports pagination and type filtering per PRD specifications.
+
+## Technical Specifications
+
+### Service Location
+
+`app/Domains/Categories/Actions/IndexCategoriesService.php`
+
+### Service Structure
+
+```php
+namespace App\Domains\Categories\Actions;
+
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Infrastructure\Mappers\CategoryMapper;
+
+class IndexCategoriesService
+{
+    public function __construct(
+        private ICategoryRepository $repository,
+        private CategoryMapper $mapper
+    ) {}
+
+    /**
+     * Execute the index categories use case
+     *
+     * @param int $page Page number (min: 1)
+     * @param int $limit Items per page (min: 1, max: 100)
+     * @param string|null $type Filter by type ('income' or 'expense')
+     * @return array CategoryListDTO with data and pagination
+     */
+    public function execute(int $page = 1, int $limit = 20, ?string $type = null): array
+    {
+        // Validate parameters
+        $page = max(1, $page);
+        $limit = min(100, max(1, $limit));
+
+        if ($type !== null && !in_array($type, ['income', 'expense'])) {
+            throw new \InvalidArgumentException('Type must be income or expense');
+        }
+
+        // Get paginated results from repository
+        $result = $this->repository->findAll($page, $limit, $type);
+
+        // Transform entities to DTOs
+        $result['data'] = $this->mapper->toDTOCollection($result['data']);
+
+        return $result;
+    }
+}
+```
+
+### Response Structure (PRD Lines 202-221)
+
+```json
+{
+    "data": [
+        {
+            "id": 1,
+            "name": "Groceries",
+            "type": "expense",
+            "notes": "Food and household items",
+            "isRecurring": false,
+            "createdAt": "2024-12-19T10:00:00Z"
+        }
+    ],
+    "pagination": {
+        "currentPage": 1,
+        "totalPages": 5,
+        "totalItems": 100,
+        "itemsPerPage": 20
+    }
+}
+```
+
+### Business Logic (PRD Lines 223-228)
+
+1. Authenticate user (handled by middleware)
+2. Query categories for user (repository handles user scoping)
+3. Apply pagination and filtering
+4. Return formatted response
+
+## Implementation Tasks
+
+1. Create IndexCategoriesService class
+2. Inject repository and mapper dependencies
+3. Implement `execute()` method
+4. Add parameter validation (bounds checking)
+5. Call repository with correct parameters
+6. Transform entity collection to DTO collection
+7. Return response with data and pagination metadata
+8. Add comprehensive PHPDoc
+9. Write unit tests
+
+## Test Cases
+
+### Happy Path Tests
+
+```php
+describe('IndexCategoriesService Happy Path', function () {
+    it('returns paginated categories with default parameters');
+    it('returns categories for specific page');
+    it('returns categories with custom limit');
+    it('returns categories filtered by income type');
+    it('returns categories filtered by expense type');
+    it('returns data and pagination metadata');
+    it('transforms entities to DTOs correctly');
+});
+```
+
+### Pagination Tests
+
+```php
+describe('IndexCategoriesService Pagination', function () {
+    it('defaults to page 1 when not specified');
+    it('defaults to limit 20 when not specified');
+    it('enforces minimum page of 1');
+    it('enforces minimum limit of 1');
+    it('enforces maximum limit of 100');
+    it('calculates total pages correctly');
+    it('returns correct currentPage in metadata');
+    it('returns correct itemsPerPage in metadata');
+    it('handles last page with partial results');
+});
+```
+
+### Filtering Tests
+
+```php
+describe('IndexCategoriesService Filtering', function () {
+    it('returns all categories when type is null');
+    it('returns only income categories when type is income');
+    it('returns only expense categories when type is expense');
+    it('throws exception for invalid type');
+    it('is case-sensitive for type parameter');
+});
+```
+
+### Empty Results Tests
+
+```php
+describe('IndexCategoriesService Empty Results', function () {
+    it('returns empty data array when no categories');
+    it('returns zero totalItems when no categories');
+    it('returns pagination metadata for empty results');
+    it('returns empty data for filtered type with no matches');
+});
+```
+
+### Parameter Validation Tests
+
+```php
+describe('IndexCategoriesService Parameter Validation', function () {
+    it('coerces negative page to 1');
+    it('coerces zero page to 1');
+    it('coerces negative limit to 1');
+    it('coerces zero limit to 1');
+    it('coerces limit over 100 to 100');
+    it('accepts valid type values');
+    it('rejects invalid type values');
+});
+```
+
+### Integration Tests
+
+```php
+describe('IndexCategoriesService Integration', function () {
+    it('calls repository with correct parameters');
+    it('calls mapper for each entity');
+    it('preserves pagination metadata from repository');
+    it('returns consistent response structure');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('IndexCategoriesService Edge Cases', function () {
+    it('handles requesting page beyond available pages');
+    it('handles limit larger than total items');
+    it('handles exactly one page of results');
+    it('handles exactly limit results');
+    it('maintains user isolation via repository');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] IndexCategoriesService class created at correct location
+-   [ ] Constructor injects repository and mapper
+-   [ ] `execute()` method implemented with all parameters
+-   [ ] Pagination parameters validated (bounds checking)
+-   [ ] Type parameter validated (income/expense only)
+-   [ ] Repository called with correct parameters
+-   [ ] Entity collection transformed to DTO collection
+-   [ ] Response structure matches PRD specification
+-   [ ] Empty results handled gracefully
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 35+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create 25 categories via seeder
+-   [ ] Call service with page=1, limit=10
+-   [ ] Verify 10 items returned with correct pagination
+-   [ ] Call service with page=3, limit=10
+-   [ ] Verify correct items for page 3
+-   [ ] Call service with type='income'
+-   [ ] Verify only income categories returned
+-   [ ] Call service with page=-1
+-   [ ] Verify coerced to page 1
+-   [ ] Call service with limit=200
+-   [ ] Verify coerced to limit 100
+-   [ ] Run tests: `php artisan test --filter=IndexCategoriesServiceTest`
+
+## Notes
+
+-   Service is application layer - orchestrates domain and infrastructure
+-   No direct database access - uses repository
+-   User authentication handled by middleware
+-   User isolation enforced by repository
+-   Parameter validation prevents invalid queries
+-   Repository handles caching internally
+-   Response format must match frontend expectations exactly
+
+## Related PRD Sections
+
+-   **Endpoint 1: List Categories:** Lines 182-228
+-   **Use Cases:** Lines 420-425
+-   **API Response Format:** Lines 202-221
+-   **Pagination Logic:** Lines 213-220
+-   **Filtering Logic:** Lines 188-199

--- a/.development-context/tickets/categories/TICKET-009.md
+++ b/.development-context/tickets/categories/TICKET-009.md
@@ -1,0 +1,211 @@
+# TICKET-009: ShowCategory Use Case
+
+**Estimate:** 2 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-006, TICKET-007  
+**PRD Reference:** Lines 277-299, 420-425
+
+## Overview
+
+Implement the ShowCategoryAction use case that retrieves a single category by ID. This service orchestrates the repository layer, handles not found scenarios, and returns properly formatted DTOs for the API layer. Leverages repository caching for performance.
+
+## Technical Specifications
+
+### Service Location
+
+`app/Domains/Categories/Actions/ShowCategoryAction.php`
+
+### Service Structure
+
+```php
+namespace App\Domains\Categories\Actions;
+
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Infrastructure\Mappers\CategoryMapper;
+use App\Domains\Categories\Exceptions\CategoryNotFoundException;
+
+class ShowCategoryAction
+{
+    public function __construct(
+        private ICategoryRepository $repository,
+        private CategoryMapper $mapper
+    ) {}
+
+    /**
+     * Execute the show category use case
+     *
+     * @param int $id Category ID
+     * @return array Category DTO
+     * @throws CategoryNotFoundException When category not found
+     */
+    public function execute(int $id): array
+    {
+        $entity = $this->repository->findById($id);
+
+        return $this->mapper->toDTO($entity);
+    }
+}
+```
+
+### Response Structure (PRD Lines 283-295)
+
+```json
+{
+    "data": {
+        "id": 1,
+        "name": "Groceries",
+        "type": "expense",
+        "notes": "Food and household items",
+        "isRecurring": false,
+        "createdAt": "2024-12-19T10:00:00Z"
+    }
+}
+```
+
+### Error Handling (PRD Lines 297-299)
+
+**Error Response (404):**
+
+```json
+{
+    "error": {
+        "message": "Category not found",
+        "code": "CATEGORY_NOT_FOUND"
+    }
+}
+```
+
+## Implementation Tasks
+
+1. Create ShowCategoryAction class
+2. Inject repository and mapper dependencies
+3. Implement `execute()` method
+4. Call repository findById
+5. Transform entity to DTO
+6. Let CategoryNotFoundException bubble up to controller
+7. Add comprehensive PHPDoc
+8. Write unit tests
+
+## Test Cases
+
+### Happy Path Tests
+
+```php
+describe('ShowCategoryAction Happy Path', function () {
+    it('returns category DTO when found');
+    it('includes all category fields in response');
+    it('transforms entity to DTO correctly');
+    it('preserves all entity data');
+});
+```
+
+### Not Found Tests
+
+```php
+describe('ShowCategoryAction Not Found', function () {
+    it('throws CategoryNotFoundException when not found');
+    it('includes category ID in exception message');
+    it('propagates exception from repository');
+});
+```
+
+### Caching Tests
+
+```php
+describe('ShowCategoryAction Caching', function () {
+    it('benefits from repository cache on first call');
+    it('benefits from repository cache on subsequent calls');
+    it('repository handles cache internally');
+});
+```
+
+### Integration Tests
+
+```php
+describe('ShowCategoryAction Integration', function () {
+    it('calls repository findById with correct ID');
+    it('calls mapper toDTO with entity');
+    it('returns DTO structure matching API spec');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('ShowCategoryAction User Isolation', function () {
+    it('throws exception when accessing another users category');
+    it('only returns categories for authenticated user');
+});
+```
+
+### Data Integrity Tests
+
+```php
+describe('ShowCategoryAction Data Integrity', function () {
+    it('returns exact entity data in DTO');
+    it('does not modify entity during transformation');
+    it('handles null notes correctly');
+    it('formats dates correctly');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('ShowCategoryAction Edge Cases', function () {
+    it('handles ID as zero');
+    it('handles negative ID');
+    it('handles very large ID');
+    it('handles newly created category');
+    it('handles category with minimal data');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] ShowCategoryAction class created at correct location
+-   [ ] Constructor injects repository and mapper
+-   [ ] `execute()` method implemented
+-   [ ] Repository findById called with correct ID
+-   [ ] Entity transformed to DTO
+-   [ ] CategoryNotFoundException propagated to caller
+-   [ ] Response structure matches PRD specification
+-   [ ] User isolation enforced via repository
+-   [ ] Caching leveraged via repository
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 20+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create category via seeder with ID 1
+-   [ ] Call service with ID 1
+-   [ ] Verify category returned with all fields
+-   [ ] Verify date format: `2024-12-19T10:00:00Z`
+-   [ ] Call service with non-existent ID 999
+-   [ ] Verify CategoryNotFoundException thrown
+-   [ ] Verify exception message includes ID
+-   [ ] Create category as user A
+-   [ ] Attempt to retrieve as user B
+-   [ ] Verify exception thrown (user isolation)
+-   [ ] Run tests: `php artisan test --filter=ShowCategoryActionTest`
+
+## Notes
+
+-   Service is application layer - orchestrates domain and infrastructure
+-   No direct database access - uses repository
+-   User authentication handled by middleware
+-   User isolation enforced by repository
+-   Repository handles caching internally (24-hour TTL per PRD)
+-   Exception handling delegated to controller/exception handler
+-   Service remains thin - just orchestration logic
+-   Response format must match frontend expectations exactly
+
+## Related PRD Sections
+
+-   **Endpoint 3: Get Category:** Lines 277-299
+-   **Use Cases:** Lines 420-425
+-   **API Response Format:** Lines 283-295
+-   **Error Handling:** Lines 297-299, 606-611
+-   **Caching Strategy:** Lines 505-525 (single category: 24 hours)
+-   **Exception Hierarchy:** Lines 595-603

--- a/.development-context/tickets/categories/TICKET-010.md
+++ b/.development-context/tickets/categories/TICKET-010.md
@@ -1,0 +1,282 @@
+# TICKET-010: StoreCategory Use Case
+
+**Estimate:** 3-4 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-006, TICKET-007  
+**PRD Reference:** Lines 231-275, 420-425
+
+## Overview
+
+Implement the StoreCategoryAction use case that creates new categories with full validation. This service creates domain entities, validates business rules, persists via repository, and handles cache invalidation. Enforces uniqueness constraints per PRD specifications.
+
+## Technical Specifications
+
+### Service Location
+
+`app/Domains/Categories/Actions/StoreCategoryAction.php`
+
+### Service Structure
+
+```php
+namespace App\Domains\Categories\Actions;
+
+use App\Domains\Categories\Entities\Category;
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Infrastructure\Mappers\CategoryMapper;
+use App\Domains\Categories\Exceptions\CategoryAlreadyExistsException;
+
+class StoreCategoryAction
+{
+    public function __construct(
+        private ICategoryRepository $repository,
+        private CategoryMapper $mapper
+    ) {}
+
+    /**
+     * Execute the store category use case
+     *
+     * @param string $name Category name (required, max 255)
+     * @param string $type Category type ('income' or 'expense')
+     * @param string|null $notes Optional notes (max 1000)
+     * @return array Created category DTO
+     * @throws CategoryAlreadyExistsException When name already exists
+     * @throws InvalidCategoryNameException When name validation fails
+     * @throws InvalidCategoryTypeException When type validation fails
+     * @throws InvalidCategoryNotesException When notes validation fails
+     */
+    public function execute(string $name, string $type, ?string $notes = null): array
+    {
+        // Create entity (validates in constructor)
+        $entity = new Category(
+            name: $name,
+            type: $type,
+            notes: $notes,
+            isRecurring: false
+        );
+
+        // Persist via repository (checks uniqueness and invalidates cache)
+        $createdEntity = $this->repository->create($entity);
+
+        // Transform to DTO
+        return $this->mapper->toDTO($createdEntity);
+    }
+}
+```
+
+### Request Structure (PRD Lines 236-243)
+
+```json
+{
+    "name": "Groceries",
+    "type": "expense",
+    "notes": "Food and household items"
+}
+```
+
+### Response Structure (PRD Lines 250-262)
+
+```json
+{
+    "data": {
+        "id": 1,
+        "name": "Groceries",
+        "type": "expense",
+        "notes": "Food and household items",
+        "isRecurring": false,
+        "createdAt": "2024-12-19T10:00:00Z"
+    }
+}
+```
+
+### Validation Rules (PRD Lines 245-249, 553-575)
+
+-   **name:** required, string, max: 255, unique
+-   **type:** required, string, in: income,expense
+-   **notes:** nullable, string, max: 1000
+
+### Business Logic (PRD Lines 268-275)
+
+1. Validate input data (entity constructor)
+2. Check name uniqueness (repository)
+3. Create category entity
+4. Persist to database (repository)
+5. Invalidate cache (repository)
+6. Return created category DTO
+
+### Error Handling (PRD Lines 264-267)
+
+-   **400:** Validation errors (entity validation)
+-   **409:** Category name already exists
+
+## Implementation Tasks
+
+1. Create StoreCategoryAction class
+2. Inject repository and mapper dependencies
+3. Implement `execute()` method
+4. Create Category entity with provided data
+5. Call repository create method
+6. Let exceptions bubble up (entity validation, uniqueness)
+7. Transform created entity to DTO
+8. Add comprehensive PHPDoc
+9. Write unit tests
+
+## Test Cases
+
+### Happy Path Tests
+
+```php
+describe('StoreCategoryAction Happy Path', function () {
+    it('creates category with all fields');
+    it('creates category with minimal fields');
+    it('creates category with null notes');
+    it('sets isRecurring to false by default');
+    it('returns DTO with generated ID');
+    it('returns DTO with createdAt timestamp');
+    it('transforms created entity correctly');
+});
+```
+
+### Uniqueness Tests
+
+```php
+describe('StoreCategoryAction Uniqueness', function () {
+    it('throws exception when name already exists');
+    it('allows same name for different users');
+    it('is case-sensitive for uniqueness check');
+    it('checks uniqueness before persistence');
+});
+```
+
+### Validation Tests
+
+```php
+describe('StoreCategoryAction Validation', function () {
+    it('throws exception when name is empty');
+    it('throws exception when name exceeds 255 characters');
+    it('throws exception when type is invalid');
+    it('throws exception when notes exceed 1000 characters');
+    it('accepts valid income type');
+    it('accepts valid expense type');
+    it('accepts null notes');
+    it('validates data via entity constructor');
+});
+```
+
+### Cache Invalidation Tests
+
+```php
+describe('StoreCategoryAction Cache Invalidation', function () {
+    it('invalidates list cache after creation');
+    it('invalidates user categories cache after creation');
+    it('repository handles cache invalidation');
+});
+```
+
+### Integration Tests
+
+```php
+describe('StoreCategoryAction Integration', function () {
+    it('creates entity from input data');
+    it('calls repository create with entity');
+    it('persists category to database');
+    it('returns DTO matching API spec');
+    it('includes all required fields in response');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('StoreCategoryAction User Isolation', function () {
+    it('associates category with authenticated user');
+    it('allows duplicate names across different users');
+    it('only checks uniqueness within user scope');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('StoreCategoryAction Edge Cases', function () {
+    it('handles name at exactly 255 characters');
+    it('handles notes at exactly 1000 characters');
+    it('handles unicode characters in name');
+    it('handles special characters in notes');
+    it('trims whitespace from name');
+    it('rejects whitespace-only name');
+});
+```
+
+### Exception Handling Tests
+
+```php
+describe('StoreCategoryAction Exception Handling', function () {
+    it('propagates CategoryAlreadyExistsException');
+    it('propagates InvalidCategoryNameException');
+    it('propagates InvalidCategoryTypeException');
+    it('propagates InvalidCategoryNotesException');
+    it('includes helpful error messages');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] StoreCategoryAction class created at correct location
+-   [ ] Constructor injects repository and mapper
+-   [ ] `execute()` method implemented
+-   [ ] Category entity created with input data
+-   [ ] Entity validation performed in constructor
+-   [ ] Repository create called with entity
+-   [ ] Uniqueness check enforced by repository
+-   [ ] Cache invalidation handled by repository
+-   [ ] Created entity transformed to DTO
+-   [ ] Response structure matches PRD specification
+-   [ ] All exceptions properly propagated
+-   [ ] User isolation enforced via repository
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 35+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create category with valid data
+-   [ ] Verify category persisted with ID
+-   [ ] Verify createdAt timestamp set
+-   [ ] Verify isRecurring defaults to false
+-   [ ] Create category with duplicate name
+-   [ ] Verify CategoryAlreadyExistsException thrown
+-   [ ] Create category with empty name
+-   [ ] Verify CategoryNameEmptyException thrown
+-   [ ] Create category with name over 255 chars
+-   [ ] Verify InvalidCategoryNameException thrown
+-   [ ] Create category with invalid type 'other'
+-   [ ] Verify InvalidCategoryTypeException thrown
+-   [ ] Create category with notes over 1000 chars
+-   [ ] Verify InvalidCategoryNotesException thrown
+-   [ ] Create category as user A
+-   [ ] Create category with same name as user B
+-   [ ] Verify both succeed (user isolation)
+-   [ ] Run tests: `php artisan test --filter=StoreCategoryActionTest`
+
+## Notes
+
+-   Service is application layer - orchestrates domain and infrastructure
+-   Entity constructor validates business rules
+-   Repository checks uniqueness and handles persistence
+-   Repository handles cache invalidation automatically
+-   User ID set by repository from auth context
+-   No direct database access in service
+-   isRecurring defaults to false for regular categories
+-   Exception messages should be clear and actionable
+-   Response format must match frontend expectations exactly
+
+## Related PRD Sections
+
+-   **Endpoint 2: Create Category:** Lines 231-275
+-   **Use Cases:** Lines 420-425
+-   **Validation Rules - Entity:** Lines 553-575
+-   **Validation Rules - Form Request:** Lines 578-589
+-   **Business Logic:** Lines 268-275
+-   **Error Handling:** Lines 264-267, 606-611
+-   **Caching Strategy - Invalidation:** Lines 519-525
+-   **Exception Hierarchy:** Lines 595-603

--- a/.development-context/tickets/categories/TICKET-011.md
+++ b/.development-context/tickets/categories/TICKET-011.md
@@ -1,0 +1,328 @@
+# TICKET-011: UpdateCategory Use Case
+
+**Estimate:** 3-4 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-006, TICKET-007  
+**PRD Reference:** Lines 301-333, 420-425
+
+## Overview
+
+Implement the UpdateCategoryAction use case that updates existing categories with full validation. This service validates business rules, handles uniqueness checks excluding self, persists changes via repository, and handles cache invalidation. Supports partial updates per PRD specifications.
+
+## Technical Specifications
+
+### Service Location
+
+`app/Domains/Categories/Actions/UpdateCategoryAction.php`
+
+### Service Structure
+
+```php
+namespace App\Domains\Categories\Actions;
+
+use App\Domains\Categories\Entities\Category;
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Infrastructure\Mappers\CategoryMapper;
+use App\Domains\Categories\Exceptions\{
+    CategoryNotFoundException,
+    CategoryAlreadyExistsException
+};
+
+class UpdateCategoryAction
+{
+    public function __construct(
+        private ICategoryRepository $repository,
+        private CategoryMapper $mapper
+    ) {}
+
+    /**
+     * Execute the update category use case
+     *
+     * @param int $id Category ID
+     * @param array $data Update data ['name', 'type', 'notes']
+     * @return array Updated category DTO
+     * @throws CategoryNotFoundException When category not found
+     * @throws CategoryAlreadyExistsException When new name conflicts
+     * @throws InvalidCategoryNameException When name validation fails
+     * @throws InvalidCategoryTypeException When type validation fails
+     * @throws InvalidCategoryNotesException When notes validation fails
+     */
+    public function execute(int $id, array $data): array
+    {
+        // Get existing category
+        $entity = $this->repository->findById($id);
+
+        // Apply updates to entity (validates changes)
+        if (isset($data['name'])) {
+            $entity->changeName($data['name']);
+        }
+
+        if (isset($data['type'])) {
+            $entity->changeType($data['type']);
+        }
+
+        if (array_key_exists('notes', $data)) {
+            $entity->updateNotes($data['notes']);
+        }
+
+        // Persist via repository (checks uniqueness and invalidates cache)
+        $updatedEntity = $this->repository->update($entity);
+
+        // Transform to DTO
+        return $this->mapper->toDTO($updatedEntity);
+    }
+}
+```
+
+### Request Structure (PRD Lines 307-313)
+
+```json
+{
+    "name": "Food & Groceries",
+    "notes": "Updated description"
+}
+```
+
+### Response Structure (PRD Lines 320-332)
+
+```json
+{
+    "data": {
+        "id": 1,
+        "name": "Food & Groceries",
+        "type": "expense",
+        "notes": "Updated description",
+        "isRecurring": false,
+        "createdAt": "2024-12-19T10:00:00Z"
+    }
+}
+```
+
+### Validation Rules (PRD Lines 315-319)
+
+-   **name:** string, max: 255, unique (if changed, excluding current)
+-   **type:** string, in: income,expense
+-   **notes:** nullable, string, max: 1000
+
+### Business Logic
+
+1. Find existing category by ID
+2. Validate input data (entity methods)
+3. Check name uniqueness excluding self (repository)
+4. Apply changes to entity
+5. Persist to database (repository)
+6. Invalidate cache (repository)
+7. Return updated category DTO
+
+### Error Handling
+
+-   **404:** Category not found
+-   **409:** New name conflicts with existing category
+-   **400:** Validation errors (entity validation)
+
+## Implementation Tasks
+
+1. Create UpdateCategoryAction class
+2. Inject repository and mapper dependencies
+3. Implement `execute()` method
+4. Retrieve existing category entity
+5. Apply updates using entity business methods
+6. Call repository update method
+7. Let exceptions bubble up (not found, uniqueness, validation)
+8. Transform updated entity to DTO
+9. Add comprehensive PHPDoc
+10. Write unit tests
+
+## Test Cases
+
+### Happy Path Tests
+
+```php
+describe('UpdateCategoryAction Happy Path', function () {
+    it('updates category name only');
+    it('updates category type only');
+    it('updates category notes only');
+    it('updates all fields at once');
+    it('updates to null notes');
+    it('returns DTO with updated data');
+    it('preserves unchanged fields');
+    it('preserves ID and createdAt');
+});
+```
+
+### Uniqueness Tests
+
+```php
+describe('UpdateCategoryAction Uniqueness', function () {
+    it('throws exception when new name already exists');
+    it('allows updating to same name');
+    it('allows same name for different users');
+    it('excludes self when checking uniqueness');
+    it('is case-sensitive for uniqueness check');
+});
+```
+
+### Not Found Tests
+
+```php
+describe('UpdateCategoryAction Not Found', function () {
+    it('throws exception when category not found');
+    it('throws exception for another users category');
+    it('includes category ID in exception message');
+});
+```
+
+### Validation Tests
+
+```php
+describe('UpdateCategoryAction Validation', function () {
+    it('throws exception when name is empty');
+    it('throws exception when name exceeds 255 characters');
+    it('throws exception when type is invalid');
+    it('throws exception when notes exceed 1000 characters');
+    it('accepts valid income type');
+    it('accepts valid expense type');
+    it('accepts null notes');
+    it('validates via entity business methods');
+});
+```
+
+### Partial Update Tests
+
+```php
+describe('UpdateCategoryAction Partial Updates', function () {
+    it('updates only provided fields');
+    it('preserves fields not in update data');
+    it('handles empty update data');
+    it('handles update with only notes');
+    it('allows changing only type');
+});
+```
+
+### Cache Invalidation Tests
+
+```php
+describe('UpdateCategoryAction Cache Invalidation', function () {
+    it('invalidates specific category cache');
+    it('invalidates list cache after update');
+    it('invalidates user categories cache');
+    it('repository handles cache invalidation');
+});
+```
+
+### Integration Tests
+
+```php
+describe('UpdateCategoryAction Integration', function () {
+    it('retrieves entity from repository');
+    it('applies changes via entity methods');
+    it('calls repository update with entity');
+    it('persists changes to database');
+    it('returns DTO matching API spec');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('UpdateCategoryAction User Isolation', function () {
+    it('throws exception updating another users category');
+    it('only checks uniqueness within user scope');
+    it('maintains user association after update');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('UpdateCategoryAction Edge Cases', function () {
+    it('handles name at exactly 255 characters');
+    it('handles notes at exactly 1000 characters');
+    it('handles unicode characters in name');
+    it('handles special characters in notes');
+    it('handles updating multiple times consecutively');
+    it('handles updating to identical values');
+});
+```
+
+### Exception Handling Tests
+
+```php
+describe('UpdateCategoryAction Exception Handling', function () {
+    it('propagates CategoryNotFoundException');
+    it('propagates CategoryAlreadyExistsException');
+    it('propagates InvalidCategoryNameException');
+    it('propagates InvalidCategoryTypeException');
+    it('propagates InvalidCategoryNotesException');
+    it('includes helpful error messages');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] UpdateCategoryAction class created at correct location
+-   [ ] Constructor injects repository and mapper
+-   [ ] `execute()` method implemented
+-   [ ] Existing category retrieved by ID
+-   [ ] Updates applied via entity business methods
+-   [ ] Entity validation performed in business methods
+-   [ ] Repository update called with entity
+-   [ ] Uniqueness check excludes self
+-   [ ] Cache invalidation handled by repository
+-   [ ] Updated entity transformed to DTO
+-   [ ] Response structure matches PRD specification
+-   [ ] Partial updates supported
+-   [ ] All exceptions properly propagated
+-   [ ] User isolation enforced via repository
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 45+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create category with name "Groceries"
+-   [ ] Update category name to "Food"
+-   [ ] Verify name changed, other fields unchanged
+-   [ ] Update category with same name
+-   [ ] Verify no exception (excluding self)
+-   [ ] Create second category "Entertainment"
+-   [ ] Update first category name to "Entertainment"
+-   [ ] Verify CategoryAlreadyExistsException thrown
+-   [ ] Update category ID 999 (non-existent)
+-   [ ] Verify CategoryNotFoundException thrown
+-   [ ] Update category with empty name
+-   [ ] Verify CategoryNameEmptyException thrown
+-   [ ] Update category with name over 255 chars
+-   [ ] Verify InvalidCategoryNameException thrown
+-   [ ] Update category with invalid type 'other'
+-   [ ] Verify InvalidCategoryTypeException thrown
+-   [ ] Create category as user A
+-   [ ] Attempt to update as user B
+-   [ ] Verify exception thrown (user isolation)
+-   [ ] Run tests: `php artisan test --filter=UpdateCategoryActionTest`
+
+## Notes
+
+-   Service is application layer - orchestrates domain and infrastructure
+-   Entity business methods validate changes
+-   Repository checks uniqueness excluding self
+-   Repository handles cache invalidation automatically
+-   User isolation enforced by repository
+-   No direct database access in service
+-   Supports partial updates (only provided fields)
+-   Empty update data is valid (no-op)
+-   Exception messages should be clear and actionable
+-   Response format must match frontend expectations exactly
+-   isRecurring and createdAt cannot be changed via update
+
+## Related PRD Sections
+
+-   **Endpoint 4: Update Category:** Lines 301-333
+-   **Use Cases:** Lines 420-425
+-   **Validation Rules - Entity:** Lines 553-575
+-   **Validation Rules - Form Request:** Lines 315-319
+-   **Business Logic:** PRD update flow
+-   **Error Handling:** Lines 606-611
+-   **Caching Strategy - Invalidation:** Lines 519-525
+-   **Exception Hierarchy:** Lines 595-603
+-   **Business Rule - Uniqueness:** Lines 530-535

--- a/.development-context/tickets/categories/TICKET-012.md
+++ b/.development-context/tickets/categories/TICKET-012.md
@@ -1,0 +1,273 @@
+# TICKET-012: DeleteCategory Use Case
+
+**Estimate:** 3-4 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-006, TICKET-007  
+**PRD Reference:** Lines 335-353, 420-425
+
+## Overview
+
+Implement the DeleteCategoryAction use case that safely deletes categories with dependency checking. This service enforces business rules preventing deletion of categories with associated transactions or recurring transactions, handles cache invalidation, and maintains data integrity per PRD specifications.
+
+## Technical Specifications
+
+### Service Location
+
+`app/Domains/Categories/Actions/DeleteCategoryAction.php`
+
+### Service Structure
+
+```php
+namespace App\Domains\Categories\Actions;
+
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Exceptions\{
+    CategoryNotFoundException,
+    CategoryHasTransactionsException
+};
+
+class DeleteCategoryAction
+{
+    public function __construct(
+        private ICategoryRepository $repository
+    ) {}
+
+    /**
+     * Execute the delete category use case
+     *
+     * @param int $id Category ID
+     * @return void
+     * @throws CategoryNotFoundException When category not found
+     * @throws CategoryHasTransactionsException When category has dependencies
+     */
+    public function execute(int $id): void
+    {
+        // Repository handles:
+        // 1. Finding category (throws if not found)
+        // 2. Checking for transactions
+        // 3. Checking for recurring transactions
+        // 4. Deletion
+        // 5. Cache invalidation
+        $this->repository->delete($id);
+    }
+}
+```
+
+### Response (PRD Line 341)
+
+**Success (204):** No content
+
+### Error Handling (PRD Lines 343-353)
+
+**Error Response (404):**
+
+```json
+{
+    "error": {
+        "message": "Category not found",
+        "code": "CATEGORY_NOT_FOUND"
+    }
+}
+```
+
+**Error Response (409):**
+
+```json
+{
+    "error": {
+        "message": "Cannot delete category with transactions",
+        "code": "CATEGORY_HAS_TRANSACTIONS"
+    }
+}
+```
+
+### Business Logic (PRD Lines 347-353)
+
+1. Find category by ID
+2. Check for associated transactions
+3. Check for associated recurring transactions
+4. Delete if no dependencies
+5. Invalidate cache
+
+### Business Rule (PRD Lines 536-541)
+
+**Rule 2: Category Deletion Protection**
+
+-   Cannot delete categories with associated transactions
+-   Cannot delete categories with associated recurring transactions
+-   Check foreign key constraints before deletion
+
+## Implementation Tasks
+
+1. Create DeleteCategoryAction class
+2. Inject repository dependency
+3. Implement `execute()` method
+4. Delegate all logic to repository delete method
+5. Let exceptions bubble up (not found, has transactions)
+6. Add comprehensive PHPDoc
+7. Write unit tests
+
+## Test Cases
+
+### Happy Path Tests
+
+```php
+describe('DeleteCategoryAction Happy Path', function () {
+    it('deletes category when no dependencies');
+    it('deletes category with no transactions');
+    it('deletes category with no recurring transactions');
+    it('returns void on successful deletion');
+    it('delegates to repository delete method');
+});
+```
+
+### Not Found Tests
+
+```php
+describe('DeleteCategoryAction Not Found', function () {
+    it('throws exception when category not found');
+    it('throws exception for another users category');
+    it('includes category ID in exception message');
+    it('propagates exception from repository');
+});
+```
+
+### Dependency Protection Tests
+
+```php
+describe('DeleteCategoryAction Dependency Protection', function () {
+    it('throws exception when category has transactions');
+    it('throws exception when category has recurring transactions');
+    it('throws exception when category has both');
+    it('includes helpful error message');
+    it('does not delete when dependencies exist');
+});
+```
+
+### Cache Invalidation Tests
+
+```php
+describe('DeleteCategoryAction Cache Invalidation', function () {
+    it('invalidates specific category cache');
+    it('invalidates list cache after deletion');
+    it('invalidates user categories cache');
+    it('repository handles cache invalidation');
+});
+```
+
+### Integration Tests
+
+```php
+describe('DeleteCategoryAction Integration', function () {
+    it('calls repository delete with ID');
+    it('removes category from database');
+    it('verifies deletion via findById throws exception');
+    it('maintains database integrity');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('DeleteCategoryAction User Isolation', function () {
+    it('throws exception deleting another users category');
+    it('only deletes categories for authenticated user');
+    it('enforces user isolation via repository');
+});
+```
+
+### Transaction Dependency Tests
+
+```php
+describe('DeleteCategoryAction Transaction Dependencies', function () {
+    it('checks for one-time transactions');
+    it('checks for recurring transactions');
+    it('prevents deletion with any dependencies');
+    it('allows deletion after all transactions removed');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('DeleteCategoryAction Edge Cases', function () {
+    it('handles deleting newly created category');
+    it('handles deleting category multiple times fails second time');
+    it('handles concurrent deletion attempts');
+    it('handles ID as zero');
+    it('handles negative ID');
+});
+```
+
+### Exception Handling Tests
+
+```php
+describe('DeleteCategoryAction Exception Handling', function () {
+    it('propagates CategoryNotFoundException');
+    it('propagates CategoryHasTransactionsException');
+    it('includes helpful error messages');
+    it('does not modify data when exception thrown');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] DeleteCategoryAction class created at correct location
+-   [ ] Constructor injects repository
+-   [ ] `execute()` method implemented
+-   [ ] Repository delete called with ID
+-   [ ] Dependency checks enforced by repository
+-   [ ] CategoryNotFoundException propagated
+-   [ ] CategoryHasTransactionsException propagated
+-   [ ] Cache invalidation handled by repository
+-   [ ] User isolation enforced via repository
+-   [ ] No content returned on success
+-   [ ] PHPDoc on all methods
+-   [ ] 100% unit test coverage
+-   [ ] All 30+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create category with no transactions
+-   [ ] Delete category
+-   [ ] Verify successful deletion (204)
+-   [ ] Attempt to find deleted category
+-   [ ] Verify CategoryNotFoundException thrown
+-   [ ] Create category and add transaction
+-   [ ] Attempt to delete category
+-   [ ] Verify CategoryHasTransactionsException thrown
+-   [ ] Verify category still exists
+-   [ ] Create category and add recurring transaction
+-   [ ] Attempt to delete category
+-   [ ] Verify CategoryHasTransactionsException thrown
+-   [ ] Delete category ID 999 (non-existent)
+-   [ ] Verify CategoryNotFoundException thrown
+-   [ ] Create category as user A
+-   [ ] Attempt to delete as user B
+-   [ ] Verify exception thrown (user isolation)
+-   [ ] Run tests: `php artisan test --filter=DeleteCategoryActionTest`
+
+## Notes
+
+-   Service is application layer - orchestrates domain and infrastructure
+-   Service is thin - delegates all logic to repository
+-   Repository enforces business rule for deletion protection
+-   Repository checks both transactions and recurring_transactions tables
+-   Repository handles cache invalidation automatically
+-   User isolation enforced by repository
+-   No direct database access in service
+-   Delete operation is final - no soft deletes currently
+-   Exception messages should be clear and actionable
+-   Currently returns false for hasTransactions until Transactions domain exists
+-   After Transactions domain: update repository to check actual foreign keys
+
+## Related PRD Sections
+
+-   **Endpoint 5: Delete Category:** Lines 335-353
+-   **Use Cases:** Lines 420-425
+-   **Business Rule - Deletion Protection:** Lines 536-541
+-   **Business Logic:** Lines 347-353
+-   **Error Handling:** Lines 343-346, 606-611
+-   **Caching Strategy - Invalidation:** Lines 519-525
+-   **Exception Hierarchy:** Lines 595-603
+-   **Domain Model:** Lines 156-160 (business rules)

--- a/.development-context/tickets/categories/TICKET-013.md
+++ b/.development-context/tickets/categories/TICKET-013.md
@@ -1,0 +1,375 @@
+# TICKET-013: Form Request Validation
+
+**Estimate:** 2-3 hours  
+**Priority:** High  
+**Dependencies:** None  
+**PRD Reference:** Lines 245-249, 315-319, 196-199, 578-589
+
+## Overview
+
+Create Laravel Form Request classes that handle HTTP input validation before data reaches the domain layer. These requests validate data format, types, lengths, and uniqueness constraints. They provide the first line of defense against invalid input and return clear error messages per PRD specifications.
+
+## Technical Specifications
+
+### Request Locations
+
+-   `app/Http/Requests/StoreCategoryRequest.php`
+-   `app/Http/Requests/UpdateCategoryRequest.php`
+-   `app/Http/Requests/IndexCategoriesRequest.php`
+
+### StoreCategoryRequest Structure (PRD Lines 245-249, 580-589)
+
+```php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request
+     */
+    public function authorize(): bool
+    {
+        return true; // Authorization handled by middleware
+    }
+
+    /**
+     * Get the validation rules that apply to the request
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255|unique:categories,name',
+            'type' => 'required|string|in:income,expense',
+            'notes' => 'nullable|string|max:1000',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'Category name is required.',
+            'name.string' => 'Category name must be a string.',
+            'name.max' => 'Category name cannot exceed 255 characters.',
+            'name.unique' => 'A category with this name already exists.',
+            'type.required' => 'Category type is required.',
+            'type.in' => 'Category type must be either income or expense.',
+            'notes.max' => 'Category notes cannot exceed 1000 characters.',
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => 'category name',
+            'type' => 'category type',
+            'notes' => 'category notes',
+        ];
+    }
+}
+```
+
+### UpdateCategoryRequest Structure (PRD Lines 315-319)
+
+```php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Authorization handled by middleware
+    }
+
+    public function rules(): array
+    {
+        $categoryId = $this->route('category'); // Get ID from route
+
+        return [
+            'name' => [
+                'sometimes',
+                'string',
+                'max:255',
+                Rule::unique('categories', 'name')->ignore($categoryId),
+            ],
+            'type' => 'sometimes|string|in:income,expense',
+            'notes' => 'nullable|string|max:1000',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.string' => 'Category name must be a string.',
+            'name.max' => 'Category name cannot exceed 255 characters.',
+            'name.unique' => 'A category with this name already exists.',
+            'type.in' => 'Category type must be either income or expense.',
+            'notes.max' => 'Category notes cannot exceed 1000 characters.',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'category name',
+            'type' => 'category type',
+            'notes' => 'category notes',
+        ];
+    }
+}
+```
+
+### IndexCategoriesRequest Structure (PRD Lines 196-199)
+
+```php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexCategoriesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Authorization handled by middleware
+    }
+
+    public function rules(): array
+    {
+        return [
+            'page' => 'integer|min:1',
+            'limit' => 'integer|min:1|max:100',
+            'type' => 'string|in:income,expense',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'page.integer' => 'Page must be an integer.',
+            'page.min' => 'Page must be at least 1.',
+            'limit.integer' => 'Limit must be an integer.',
+            'limit.min' => 'Limit must be at least 1.',
+            'limit.max' => 'Limit cannot exceed 100.',
+            'type.in' => 'Type must be either income or expense.',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'page' => 'page number',
+            'limit' => 'items per page',
+            'type' => 'category type',
+        ];
+    }
+}
+```
+
+### Validation Error Response Format (PRD Lines 614-623)
+
+```json
+{
+    "error": {
+        "message": "Validation failed",
+        "code": "VALIDATION_ERROR",
+        "details": {
+            "name": ["The name has already been taken."],
+            "type": ["Category type must be either income or expense."]
+        }
+    }
+}
+```
+
+## Implementation Tasks
+
+1. Create StoreCategoryRequest class
+2. Implement authorization (return true)
+3. Add validation rules for create
+4. Add custom error messages
+5. Add custom attributes
+6. Create UpdateCategoryRequest class
+7. Implement partial update validation (sometimes)
+8. Add unique validation excluding self
+9. Create IndexCategoriesRequest class
+10. Add query parameter validation
+11. Test all validation rules
+12. Test custom error messages
+
+## Test Cases
+
+### StoreCategoryRequest Tests
+
+```php
+describe('StoreCategoryRequest Validation', function () {
+    it('passes with valid data');
+    it('fails when name is missing');
+    it('fails when name exceeds 255 characters');
+    it('fails when name is not unique');
+    it('fails when type is missing');
+    it('fails when type is invalid');
+    it('passes when notes is null');
+    it('fails when notes exceed 1000 characters');
+    it('returns custom error messages');
+});
+```
+
+### UpdateCategoryRequest Tests
+
+```php
+describe('UpdateCategoryRequest Validation', function () {
+    it('passes with valid partial data');
+    it('passes when updating only name');
+    it('passes when updating only type');
+    it('passes when updating only notes');
+    it('passes with no fields (no-op)');
+    it('fails when name exceeds 255 characters');
+    it('fails when name conflicts with other category');
+    it('passes when name unchanged');
+    it('fails when type is invalid');
+    it('fails when notes exceed 1000 characters');
+    it('uses sometimes validation for optional fields');
+    it('returns custom error messages');
+});
+```
+
+### IndexCategoriesRequest Tests
+
+```php
+describe('IndexCategoriesRequest Validation', function () {
+    it('passes with valid query parameters');
+    it('passes with no query parameters');
+    it('passes with only page parameter');
+    it('passes with only limit parameter');
+    it('passes with only type parameter');
+    it('fails when page is less than 1');
+    it('fails when page is not integer');
+    it('fails when limit is less than 1');
+    it('fails when limit exceeds 100');
+    it('fails when limit is not integer');
+    it('fails when type is invalid');
+    it('returns custom error messages');
+});
+```
+
+### Uniqueness Validation Tests
+
+```php
+describe('Form Request Uniqueness Validation', function () {
+    it('detects duplicate names on create');
+    it('excludes self on update');
+    it('checks uniqueness within user scope');
+    it('is case-sensitive for names');
+});
+```
+
+### Error Message Tests
+
+```php
+describe('Form Request Error Messages', function () {
+    it('returns clear error message for required name');
+    it('returns clear error message for duplicate name');
+    it('returns clear error message for invalid type');
+    it('returns clear error message for long name');
+    it('returns clear error message for long notes');
+    it('returns multiple errors when multiple rules fail');
+    it('uses custom attributes in error messages');
+});
+```
+
+### Authorization Tests
+
+```php
+describe('Form Request Authorization', function () {
+    it('always returns true for authorize');
+    it('delegates auth to middleware');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('Form Request Edge Cases', function () {
+    it('handles name at exactly 255 characters');
+    it('handles notes at exactly 1000 characters');
+    it('handles unicode characters in name');
+    it('handles special characters in notes');
+    it('handles empty string vs null for notes');
+    it('handles numeric page values');
+    it('handles string page values');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] StoreCategoryRequest class created
+-   [ ] UpdateCategoryRequest class created
+-   [ ] IndexCategoriesRequest class created
+-   [ ] All validation rules match PRD specifications
+-   [ ] `authorize()` returns true (auth via middleware)
+-   [ ] Custom error messages implemented
+-   [ ] Custom attributes implemented
+-   [ ] Unique validation works for create
+-   [ ] Unique validation excludes self for update
+-   [ ] Update uses `sometimes` for optional fields
+-   [ ] Max length validation works (255, 1000)
+-   [ ] Type validation enforces income/expense
+-   [ ] Query parameter validation works
+-   [ ] Error response format matches PRD
+-   [ ] 100% test coverage
+-   [ ] All 40+ test cases pass
+
+## Validation Checklist
+
+-   [ ] POST /categories with valid data
+-   [ ] Verify passes validation
+-   [ ] POST /categories with missing name
+-   [ ] Verify error: "Category name is required."
+-   [ ] POST /categories with name over 255 chars
+-   [ ] Verify error: "Category name cannot exceed 255 characters."
+-   [ ] POST /categories with duplicate name
+-   [ ] Verify error: "A category with this name already exists."
+-   [ ] POST /categories with invalid type "other"
+-   [ ] Verify error: "Category type must be either income or expense."
+-   [ ] PUT /categories/1 with new unique name
+-   [ ] Verify passes validation
+-   [ ] PUT /categories/1 with same name
+-   [ ] Verify passes validation (excludes self)
+-   [ ] PUT /categories/1 with other category's name
+-   [ ] Verify error: "A category with this name already exists."
+-   [ ] GET /categories?page=0
+-   [ ] Verify error: "Page must be at least 1."
+-   [ ] GET /categories?limit=200
+-   [ ] Verify error: "Limit cannot exceed 100."
+-   [ ] Run tests: `php artisan test --filter=CategoryRequestTest`
+
+## Notes
+
+-   Form Requests are HTTP layer - first line of validation
+-   Separate from domain entity validation
+-   Domain entity provides second layer of validation
+-   Authorization always returns true - handled by middleware
+-   Unique validation should be user-scoped (add user_id when implemented)
+-   Error messages should be user-friendly
+-   Error format handled by Laravel exception handler
+-   Custom error messages improve UX
+-   Update request uses `sometimes` for partial updates
+-   Query parameter validation prevents invalid requests
+
+## Related PRD Sections
+
+-   **Validation Rules - Form Request (Store):** Lines 245-249, 580-589
+-   **Validation Rules - Form Request (Update):** Lines 315-319
+-   **Query Parameter Validation:** Lines 196-199
+-   **Error Response Format:** Lines 614-623
+-   **Business Rules:** Lines 528-547
+-   **Layer Architecture - Interface Layer:** Lines 440-450

--- a/.development-context/tickets/categories/TICKET-014.md
+++ b/.development-context/tickets/categories/TICKET-014.md
@@ -1,0 +1,335 @@
+# TICKET-014: Category Controller - List & Show
+
+**Estimate:** 3-4 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-008, TICKET-009, TICKET-013  
+**PRD Reference:** Lines 182-299, 440-450, 606-623
+
+## Overview
+
+Create the CategoryController with index() and show() methods to expose category read operations through the API. The controller serves as the interface layer, delegating business logic to use case services and handling HTTP concerns like status codes, error responses, and resource formatting per PRD specifications.
+
+## Technical Specifications
+
+### Controller Location
+
+`app/Http/Controllers/CategoryController.php`
+
+### Controller Structure
+
+```php
+namespace App\Http\Controllers;
+
+use App\Http\Requests\IndexCategoriesRequest;
+use App\Domains\Categories\Actions\IndexCategoriesService;
+use App\Domains\Categories\Actions\ShowCategoryAction;
+use App\Domains\Categories\Exceptions\CategoryNotFoundException;
+use Illuminate\Http\JsonResponse;
+
+class CategoryController extends Controller
+{
+    public function __construct(
+        private IndexCategoriesService $indexService,
+        private ShowCategoryAction $showAction
+    ) {}
+
+    /**
+     * Display a listing of categories
+     *
+     * @param IndexCategoriesRequest $request
+     * @return JsonResponse
+     */
+    public function index(IndexCategoriesRequest $request): JsonResponse
+    {
+        $result = $this->indexService->execute(
+            page: $request->input('page', 1),
+            limit: $request->input('limit', 20),
+            type: $request->input('type')
+        );
+
+        return response()->json($result, 200);
+    }
+
+    /**
+     * Display the specified category
+     *
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function show(int $id): JsonResponse
+    {
+        try {
+            $category = $this->showAction->execute($id);
+            return response()->json(['data' => $category], 200);
+        } catch (CategoryNotFoundException $e) {
+            return response()->json([
+                'error' => [
+                    'message' => 'Category not found',
+                    'code' => 'CATEGORY_NOT_FOUND'
+                ]
+            ], 404);
+        }
+    }
+}
+```
+
+### Index Response Structure (PRD Lines 202-221)
+
+```json
+{
+    "data": [
+        {
+            "id": 1,
+            "name": "Groceries",
+            "type": "expense",
+            "notes": "Food and household items",
+            "isRecurring": false,
+            "createdAt": "2024-12-19T10:00:00Z"
+        }
+    ],
+    "pagination": {
+        "currentPage": 1,
+        "totalPages": 5,
+        "totalItems": 100,
+        "itemsPerPage": 20
+    }
+}
+```
+
+### Show Response Structure (PRD Lines 283-295)
+
+```json
+{
+    "data": {
+        "id": 1,
+        "name": "Groceries",
+        "type": "expense",
+        "notes": "Food and household items",
+        "isRecurring": false,
+        "createdAt": "2024-12-19T10:00:00Z"
+    }
+}
+```
+
+### Error Response Format (PRD Lines 612-623)
+
+```json
+{
+    "error": {
+        "message": "Category not found",
+        "code": "CATEGORY_NOT_FOUND"
+    }
+}
+```
+
+## Implementation Tasks
+
+1. Create CategoryController class
+2. Inject IndexCategoriesService and ShowCategoryAction
+3. Implement `index()` method
+4. Type-hint IndexCategoriesRequest for validation
+5. Extract query parameters with defaults
+6. Call IndexCategoriesService
+7. Return JSON response with 200 status
+8. Implement `show()` method
+9. Call ShowCategoryAction
+10. Wrap result in 'data' key
+11. Handle CategoryNotFoundException with 404
+12. Add comprehensive PHPDoc
+13. Write integration tests
+
+## Test Cases
+
+### Index Method Tests
+
+```php
+describe('CategoryController Index', function () {
+    it('returns paginated categories with default parameters');
+    it('returns categories for specific page');
+    it('returns categories with custom limit');
+    it('returns categories filtered by income type');
+    it('returns categories filtered by expense type');
+    it('returns 200 status code');
+    it('includes data and pagination keys');
+    it('delegates to IndexCategoriesService');
+    it('passes validated request parameters to service');
+});
+```
+
+### Index Response Format Tests
+
+```php
+describe('CategoryController Index Response Format', function () {
+    it('returns data array with category objects');
+    it('includes all category fields in each item');
+    it('includes pagination metadata');
+    it('includes currentPage in pagination');
+    it('includes totalPages in pagination');
+    it('includes totalItems in pagination');
+    it('includes itemsPerPage in pagination');
+    it('formats dates as ISO 8601');
+    it('uses camelCase for property names');
+});
+```
+
+### Index Validation Tests
+
+```php
+describe('CategoryController Index Validation', function () {
+    it('validates using IndexCategoriesRequest');
+    it('returns 422 for invalid page parameter');
+    it('returns 422 for invalid limit parameter');
+    it('returns 422 for invalid type parameter');
+    it('returns validation errors in standard format');
+});
+```
+
+### Show Method Tests
+
+```php
+describe('CategoryController Show', function () {
+    it('returns single category by ID');
+    it('returns 200 status code when found');
+    it('wraps category in data key');
+    it('delegates to ShowCategoryAction');
+    it('passes ID to action');
+});
+```
+
+### Show Error Handling Tests
+
+```php
+describe('CategoryController Show Error Handling', function () {
+    it('returns 404 when category not found');
+    it('returns error object with message');
+    it('returns error object with code');
+    it('catches CategoryNotFoundException');
+    it('formats error per PRD specification');
+    it('includes CATEGORY_NOT_FOUND code');
+});
+```
+
+### Show Response Format Tests
+
+```php
+describe('CategoryController Show Response Format', function () {
+    it('includes all category fields');
+    it('formats dates as ISO 8601');
+    it('uses camelCase for property names');
+    it('includes id field');
+    it('includes name field');
+    it('includes type field');
+    it('includes notes field');
+    it('includes isRecurring field');
+    it('includes createdAt field');
+});
+```
+
+### Authentication Tests
+
+```php
+describe('CategoryController Authentication', function () {
+    it('requires authentication for index');
+    it('requires authentication for show');
+    it('returns 401 when not authenticated');
+    it('enforces auth via middleware');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('CategoryController User Isolation', function () {
+    it('only returns authenticated users categories in index');
+    it('throws 404 when accessing another users category in show');
+    it('enforces user isolation via service layer');
+});
+```
+
+### Integration Tests
+
+```php
+describe('CategoryController Integration', function () {
+    it('integrates with IndexCategoriesService correctly');
+    it('integrates with ShowCategoryAction correctly');
+    it('integrates with IndexCategoriesRequest validation');
+    it('returns consistent response structure');
+    it('handles end-to-end request flow');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('CategoryController Edge Cases', function () {
+    it('handles empty category list');
+    it('handles single category');
+    it('handles maximum limit of 100');
+    it('handles very large page numbers');
+    it('handles ID as zero in show');
+    it('handles negative ID in show');
+    it('handles concurrent requests');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] CategoryController class created at correct location
+-   [ ] Constructor injects IndexCategoriesService and ShowCategoryAction
+-   [ ] `index()` method implemented
+-   [ ] IndexCategoriesRequest type-hinted for validation
+-   [ ] Query parameters extracted with defaults (page=1, limit=20)
+-   [ ] IndexCategoriesService called with correct parameters
+-   [ ] `show()` method implemented
+-   [ ] ShowCategoryAction called with ID
+-   [ ] CategoryNotFoundException caught and handled
+-   [ ] Response format matches PRD specification exactly
+-   [ ] Status codes correct (200, 404)
+-   [ ] Error format matches PRD specification
+-   [ ] PHPDoc on all methods
+-   [ ] 100% test coverage
+-   [ ] All 50+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Seed database with 25 categories
+-   [ ] GET /api/categories
+-   [ ] Verify 200 status code
+-   [ ] Verify response has data and pagination keys
+-   [ ] Verify first 20 categories returned
+-   [ ] GET /api/categories?page=2&limit=10
+-   [ ] Verify correct page 2 items with limit 10
+-   [ ] GET /api/categories?type=income
+-   [ ] Verify only income categories returned
+-   [ ] GET /api/categories/1
+-   [ ] Verify 200 status code
+-   [ ] Verify single category with all fields
+-   [ ] GET /api/categories/999
+-   [ ] Verify 404 status code
+-   [ ] Verify error format matches PRD
+-   [ ] GET /api/categories?page=-1
+-   [ ] Verify 422 validation error
+-   [ ] Run tests: `php artisan test --filter=CategoryControllerTest`
+
+## Notes
+
+-   Controller is interface layer - thin HTTP adapter
+-   Delegates all business logic to services
+-   Handles HTTP concerns only (requests, responses, status codes)
+-   Request validation via Form Request classes
+-   Exception handling for clean error responses
+-   Service layer enforces user isolation
+-   Response format must match frontend expectations exactly
+-   Use constructor injection for services
+-   Keep methods focused and single-purpose
+-   Return JsonResponse for type safety
+
+## Related PRD Sections
+
+-   **Endpoint 1: List Categories:** Lines 182-228
+-   **Endpoint 3: Get Category:** Lines 277-299
+-   **Layer Architecture - Interface Layer:** Lines 440-450
+-   **Error Handling:** Lines 606-623
+-   **Error Response Format:** Lines 612-623
+-   **Authentication:** Lines 670-673
+-   **Authorization:** Lines 674-676

--- a/.development-context/tickets/categories/TICKET-015.md
+++ b/.development-context/tickets/categories/TICKET-015.md
@@ -1,0 +1,320 @@
+# TICKET-015: Category Controller - Create
+
+**Estimate:** 2-3 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-010, TICKET-013, TICKET-014  
+**PRD Reference:** Lines 231-275, 440-450, 606-623
+
+## Overview
+
+Implement the store() method in CategoryController to handle category creation through the API. The controller validates input via StoreCategoryRequest, delegates creation to StoreCategoryAction, and returns properly formatted responses with correct HTTP status codes per PRD specifications.
+
+## Technical Specifications
+
+### Controller Method
+
+Add to existing `app/Http/Controllers/CategoryController.php`
+
+```php
+use App\Http\Requests\StoreCategoryRequest;
+use App\Domains\Categories\Actions\StoreCategoryAction;
+use App\Domains\Categories\Exceptions\CategoryAlreadyExistsException;
+
+public function __construct(
+    private IndexCategoriesService $indexService,
+    private ShowCategoryAction $showAction,
+    private StoreCategoryAction $storeAction
+) {}
+
+/**
+ * Store a newly created category
+ *
+ * @param StoreCategoryRequest $request
+ * @return JsonResponse
+ */
+public function store(StoreCategoryRequest $request): JsonResponse
+{
+    try {
+        $category = $this->storeAction->execute(
+            name: $request->input('name'),
+            type: $request->input('type'),
+            notes: $request->input('notes')
+        );
+
+        return response()->json(['data' => $category], 201);
+    } catch (CategoryAlreadyExistsException $e) {
+        return response()->json([
+            'error' => [
+                'message' => 'Category name already exists',
+                'code' => 'CATEGORY_EXISTS'
+            ]
+        ], 409);
+    }
+}
+```
+
+### Request Structure (PRD Lines 236-243)
+
+```json
+{
+    "name": "Groceries",
+    "type": "expense",
+    "notes": "Food and household items"
+}
+```
+
+### Response Structure (PRD Lines 250-262)
+
+```json
+{
+    "data": {
+        "id": 1,
+        "name": "Groceries",
+        "type": "expense",
+        "notes": "Food and household items",
+        "isRecurring": false,
+        "createdAt": "2024-12-19T10:00:00Z"
+    }
+}
+```
+
+### Error Responses (PRD Lines 264-267)
+
+**400 Validation Error:**
+
+```json
+{
+    "error": {
+        "message": "Validation failed",
+        "code": "VALIDATION_ERROR",
+        "details": {
+            "name": ["The name field is required."]
+        }
+    }
+}
+```
+
+**409 Duplicate Error:**
+
+```json
+{
+    "error": {
+        "message": "Category name already exists",
+        "code": "CATEGORY_EXISTS"
+    }
+}
+```
+
+## Implementation Tasks
+
+1. Add StoreCategoryAction to constructor injection
+2. Implement `store()` method
+3. Type-hint StoreCategoryRequest for validation
+4. Extract input parameters (name, type, notes)
+5. Call StoreCategoryAction with parameters
+6. Wrap result in 'data' key
+7. Return 201 status code on success
+8. Catch CategoryAlreadyExistsException
+9. Return 409 status with error format
+10. Add PHPDoc documentation
+11. Write integration tests
+
+## Test Cases
+
+### Happy Path Tests
+
+```php
+describe('CategoryController Store Happy Path', function () {
+    it('creates category with all fields');
+    it('creates category with minimal fields');
+    it('creates category with null notes');
+    it('returns 201 status code');
+    it('wraps category in data key');
+    it('returns category with generated ID');
+    it('returns category with createdAt timestamp');
+    it('delegates to StoreCategoryAction');
+    it('passes all input parameters to action');
+});
+```
+
+### Validation Tests
+
+```php
+describe('CategoryController Store Validation', function () {
+    it('validates using StoreCategoryRequest');
+    it('returns 422 when name is missing');
+    it('returns 422 when name exceeds 255 characters');
+    it('returns 422 when type is missing');
+    it('returns 422 when type is invalid');
+    it('returns 422 when notes exceed 1000 characters');
+    it('returns validation errors in standard format');
+    it('returns multiple errors for multiple violations');
+});
+```
+
+### Duplicate Handling Tests
+
+```php
+describe('CategoryController Store Duplicate Handling', function () {
+    it('returns 409 when name already exists');
+    it('catches CategoryAlreadyExistsException');
+    it('returns error object with message');
+    it('returns error object with CATEGORY_EXISTS code');
+    it('formats error per PRD specification');
+    it('does not create duplicate category');
+    it('allows same name for different users');
+});
+```
+
+### Response Format Tests
+
+```php
+describe('CategoryController Store Response Format', function () {
+    it('includes all category fields');
+    it('formats dates as ISO 8601');
+    it('uses camelCase for property names');
+    it('includes generated id field');
+    it('includes name field');
+    it('includes type field');
+    it('includes notes field');
+    it('includes isRecurring field defaulted to false');
+    it('includes createdAt timestamp');
+});
+```
+
+### Authentication Tests
+
+```php
+describe('CategoryController Store Authentication', function () {
+    it('requires authentication');
+    it('returns 401 when not authenticated');
+    it('enforces auth via middleware');
+    it('associates category with authenticated user');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('CategoryController Store User Isolation', function () {
+    it('creates category for authenticated user only');
+    it('allows duplicate names across different users');
+    it('enforces user scoping via service layer');
+});
+```
+
+### Input Handling Tests
+
+```php
+describe('CategoryController Store Input Handling', function () {
+    it('handles name at exactly 255 characters');
+    it('handles notes at exactly 1000 characters');
+    it('handles unicode characters in name');
+    it('handles special characters in notes');
+    it('handles missing optional notes field');
+    it('handles null notes value');
+});
+```
+
+### Integration Tests
+
+```php
+describe('CategoryController Store Integration', function () {
+    it('integrates with StoreCategoryAction correctly');
+    it('integrates with StoreCategoryRequest validation');
+    it('persists category to database');
+    it('invalidates cache after creation');
+    it('returns consistent response structure');
+    it('handles end-to-end creation flow');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('CategoryController Store Edge Cases', function () {
+    it('handles rapid successive creations');
+    it('handles concurrent creation attempts');
+    it('handles creation with empty notes string vs null');
+    it('handles whitespace-only name validation');
+    it('handles creation after deletion of same name');
+});
+```
+
+### Error Handling Tests
+
+```php
+describe('CategoryController Store Error Handling', function () {
+    it('catches and formats CategoryAlreadyExistsException');
+    it('propagates validation errors from request');
+    it('returns proper HTTP status codes');
+    it('includes helpful error messages');
+    it('maintains data integrity on errors');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] `store()` method implemented in CategoryController
+-   [ ] Constructor injects StoreCategoryAction
+-   [ ] StoreCategoryRequest type-hinted for validation
+-   [ ] Input parameters extracted (name, type, notes)
+-   [ ] StoreCategoryAction called with parameters
+-   [ ] Result wrapped in 'data' key
+-   [ ] 201 status returned on success
+-   [ ] CategoryAlreadyExistsException caught
+-   [ ] 409 status returned for duplicates
+-   [ ] Error format matches PRD specification
+-   [ ] Response format matches PRD specification
+-   [ ] PHPDoc on method
+-   [ ] 100% test coverage
+-   [ ] All 45+ test cases pass
+
+## Validation Checklist
+
+-   [ ] POST /api/categories with valid data
+-   [ ] Verify 201 status code
+-   [ ] Verify category created with all fields
+-   [ ] Verify generated ID present
+-   [ ] Verify createdAt timestamp set
+-   [ ] POST /api/categories with missing name
+-   [ ] Verify 422 validation error
+-   [ ] Verify error message present
+-   [ ] POST /api/categories with invalid type "other"
+-   [ ] Verify 422 validation error
+-   [ ] POST /api/categories with name over 255 chars
+-   [ ] Verify 422 validation error
+-   [ ] Create category "Groceries"
+-   [ ] POST /api/categories with same name "Groceries"
+-   [ ] Verify 409 status code
+-   [ ] Verify CATEGORY_EXISTS error code
+-   [ ] POST /api/categories without authentication
+-   [ ] Verify 401 status code
+-   [ ] Run tests: `php artisan test --filter=CategoryControllerStoreTest`
+
+## Notes
+
+-   Controller is interface layer - thin HTTP adapter
+-   Delegates all business logic to StoreCategoryAction
+-   Request validation via StoreCategoryRequest
+-   Entity validation happens in action/entity layer
+-   Two layers of validation: HTTP input and domain rules
+-   201 status indicates resource creation
+-   409 status indicates conflict (duplicate)
+-   422 status indicates validation failure
+-   Service layer enforces user isolation
+-   Cache invalidation handled by repository
+-   Response format must match frontend expectations exactly
+-   isRecurring defaults to false in entity
+
+## Related PRD Sections
+
+-   **Endpoint 2: Create Category:** Lines 231-275
+-   **Request Structure:** Lines 236-243
+-   **Response Structure:** Lines 250-262
+-   **Validation Rules:** Lines 245-249
+-   **Error Responses:** Lines 264-267
+-   **Business Logic:** Lines 268-275
+-   **Layer Architecture - Interface Layer:** Lines 440-450
+-   **Error Handling:** Lines 606-623
+-   **Exception Hierarchy:** Lines 595-603

--- a/.development-context/tickets/categories/TICKET-016.md
+++ b/.development-context/tickets/categories/TICKET-016.md
@@ -1,0 +1,394 @@
+# TICKET-016: Category Controller - Update & Delete
+
+**Estimate:** 2-3 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-011, TICKET-012, TICKET-013, TICKET-014  
+**PRD Reference:** Lines 301-353, 440-450, 606-623
+
+## Overview
+
+Implement the update() and destroy() methods in CategoryController to handle category modification and deletion through the API. The controller validates input, delegates operations to use case actions, and returns properly formatted responses with correct HTTP status codes and error handling per PRD specifications.
+
+## Technical Specifications
+
+### Controller Methods
+
+Add to existing `app/Http/Controllers/CategoryController.php`
+
+```php
+use App\Http\Requests\UpdateCategoryRequest;
+use App\Domains\Categories\Actions\{UpdateCategoryAction, DeleteCategoryAction};
+use App\Domains\Categories\Exceptions\{
+    CategoryNotFoundException,
+    CategoryAlreadyExistsException,
+    CategoryHasTransactionsException
+};
+
+public function __construct(
+    private IndexCategoriesService $indexService,
+    private ShowCategoryAction $showAction,
+    private StoreCategoryAction $storeAction,
+    private UpdateCategoryAction $updateAction,
+    private DeleteCategoryAction $deleteAction
+) {}
+
+/**
+ * Update the specified category
+ *
+ * @param UpdateCategoryRequest $request
+ * @param int $id
+ * @return JsonResponse
+ */
+public function update(UpdateCategoryRequest $request, int $id): JsonResponse
+{
+    try {
+        $category = $this->updateAction->execute($id, $request->validated());
+        return response()->json(['data' => $category], 200);
+    } catch (CategoryNotFoundException $e) {
+        return response()->json([
+            'error' => [
+                'message' => 'Category not found',
+                'code' => 'CATEGORY_NOT_FOUND'
+            ]
+        ], 404);
+    } catch (CategoryAlreadyExistsException $e) {
+        return response()->json([
+            'error' => [
+                'message' => 'Category name already exists',
+                'code' => 'CATEGORY_EXISTS'
+            ]
+        ], 409);
+    }
+}
+
+/**
+ * Remove the specified category
+ *
+ * @param int $id
+ * @return JsonResponse
+ */
+public function destroy(int $id): JsonResponse
+{
+    try {
+        $this->deleteAction->execute($id);
+        return response()->json(null, 204);
+    } catch (CategoryNotFoundException $e) {
+        return response()->json([
+            'error' => [
+                'message' => 'Category not found',
+                'code' => 'CATEGORY_NOT_FOUND'
+            ]
+        ], 404);
+    } catch (CategoryHasTransactionsException $e) {
+        return response()->json([
+            'error' => [
+                'message' => 'Cannot delete category with transactions',
+                'code' => 'CATEGORY_HAS_TRANSACTIONS'
+            ]
+        ], 409);
+    }
+}
+```
+
+### Update Request Structure (PRD Lines 307-313)
+
+```json
+{
+    "name": "Food & Groceries",
+    "notes": "Updated description"
+}
+```
+
+### Update Response Structure (PRD Lines 320-332)
+
+```json
+{
+    "data": {
+        "id": 1,
+        "name": "Food & Groceries",
+        "type": "expense",
+        "notes": "Updated description",
+        "isRecurring": false,
+        "createdAt": "2024-12-19T10:00:00Z"
+    }
+}
+```
+
+### Delete Response (PRD Line 341)
+
+**Success (204):** No content
+
+### Error Responses (PRD Lines 343-346, 612-623)
+
+**404 Not Found:**
+
+```json
+{
+    "error": {
+        "message": "Category not found",
+        "code": "CATEGORY_NOT_FOUND"
+    }
+}
+```
+
+**409 Conflict (Duplicate):**
+
+```json
+{
+    "error": {
+        "message": "Category name already exists",
+        "code": "CATEGORY_EXISTS"
+    }
+}
+```
+
+**409 Conflict (Has Dependencies):**
+
+```json
+{
+    "error": {
+        "message": "Cannot delete category with transactions",
+        "code": "CATEGORY_HAS_TRANSACTIONS"
+    }
+}
+```
+
+## Implementation Tasks
+
+1. Add UpdateCategoryAction and DeleteCategoryAction to constructor
+2. Implement `update()` method
+3. Type-hint UpdateCategoryRequest for validation
+4. Call UpdateCategoryAction with ID and validated data
+5. Handle CategoryNotFoundException (404)
+6. Handle CategoryAlreadyExistsException (409)
+7. Return 200 with updated category
+8. Implement `destroy()` method
+9. Call DeleteCategoryAction with ID
+10. Handle CategoryHasTransactionsException (409)
+11. Return 204 on successful deletion
+12. Add PHPDoc documentation
+13. Write integration tests
+
+## Test Cases
+
+### Update Method Happy Path Tests
+
+```php
+describe('CategoryController Update Happy Path', function () {
+    it('updates category with all fields');
+    it('updates category with partial fields');
+    it('updates only name');
+    it('updates only type');
+    it('updates only notes');
+    it('updates to null notes');
+    it('returns 200 status code');
+    it('wraps updated category in data key');
+    it('delegates to UpdateCategoryAction');
+    it('passes ID and validated data to action');
+});
+```
+
+### Update Validation Tests
+
+```php
+describe('CategoryController Update Validation', function () {
+    it('validates using UpdateCategoryRequest');
+    it('returns 422 when name exceeds 255 characters');
+    it('returns 422 when type is invalid');
+    it('returns 422 when notes exceed 1000 characters');
+    it('allows partial updates via sometimes rules');
+    it('returns validation errors in standard format');
+});
+```
+
+### Update Error Handling Tests
+
+```php
+describe('CategoryController Update Error Handling', function () {
+    it('returns 404 when category not found');
+    it('returns 409 when new name already exists');
+    it('catches CategoryNotFoundException');
+    it('catches CategoryAlreadyExistsException');
+    it('returns error object with message');
+    it('returns error object with code');
+    it('formats errors per PRD specification');
+});
+```
+
+### Update Response Format Tests
+
+```php
+describe('CategoryController Update Response Format', function () {
+    it('includes all category fields');
+    it('formats dates as ISO 8601');
+    it('uses camelCase for property names');
+    it('preserves unchanged fields');
+    it('preserves ID and createdAt');
+    it('reflects updated values');
+});
+```
+
+### Destroy Method Happy Path Tests
+
+```php
+describe('CategoryController Destroy Happy Path', function () {
+    it('deletes category when no dependencies');
+    it('returns 204 status code');
+    it('returns no content');
+    it('delegates to DeleteCategoryAction');
+    it('passes ID to action');
+    it('removes category from database');
+});
+```
+
+### Destroy Error Handling Tests
+
+```php
+describe('CategoryController Destroy Error Handling', function () {
+    it('returns 404 when category not found');
+    it('returns 409 when category has transactions');
+    it('returns 409 when category has recurring transactions');
+    it('catches CategoryNotFoundException');
+    it('catches CategoryHasTransactionsException');
+    it('returns error object with message');
+    it('returns error object with code');
+    it('formats errors per PRD specification');
+    it('does not delete when dependencies exist');
+});
+```
+
+### Authentication Tests
+
+```php
+describe('CategoryController Update Delete Authentication', function () {
+    it('requires authentication for update');
+    it('requires authentication for destroy');
+    it('returns 401 when not authenticated');
+    it('enforces auth via middleware');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('CategoryController Update Delete User Isolation', function () {
+    it('returns 404 updating another users category');
+    it('returns 404 deleting another users category');
+    it('enforces user isolation via service layer');
+    it('allows updating own categories only');
+    it('allows deleting own categories only');
+});
+```
+
+### Integration Tests
+
+```php
+describe('CategoryController Update Delete Integration', function () {
+    it('integrates with UpdateCategoryAction correctly');
+    it('integrates with DeleteCategoryAction correctly');
+    it('integrates with UpdateCategoryRequest validation');
+    it('persists updates to database');
+    it('removes deleted categories from database');
+    it('invalidates cache after update');
+    it('invalidates cache after delete');
+    it('returns consistent response structures');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('CategoryController Update Delete Edge Cases', function () {
+    it('handles updating with no changes');
+    it('handles updating multiple times consecutively');
+    it('handles deleting already deleted category');
+    it('handles concurrent update attempts');
+    it('handles concurrent delete attempts');
+    it('handles update after delete fails');
+    it('handles unicode characters in updates');
+});
+```
+
+### Partial Update Tests
+
+```php
+describe('CategoryController Partial Update', function () {
+    it('updates only provided fields');
+    it('preserves fields not in request');
+    it('handles empty update data');
+    it('validates only provided fields');
+    it('allows changing name without type');
+    it('allows changing type without name');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] `update()` method implemented in CategoryController
+-   [ ] `destroy()` method implemented in CategoryController
+-   [ ] Constructor injects UpdateCategoryAction and DeleteCategoryAction
+-   [ ] UpdateCategoryRequest type-hinted for validation
+-   [ ] Update delegates to UpdateCategoryAction
+-   [ ] Delete delegates to DeleteCategoryAction
+-   [ ] CategoryNotFoundException handled (404)
+-   [ ] CategoryAlreadyExistsException handled (409)
+-   [ ] CategoryHasTransactionsException handled (409)
+-   [ ] Response formats match PRD specification
+-   [ ] Status codes correct (200, 204, 404, 409)
+-   [ ] Error formats match PRD specification
+-   [ ] PHPDoc on all methods
+-   [ ] 100% test coverage
+-   [ ] All 55+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Create category "Groceries"
+-   [ ] PUT /api/categories/1 with new name "Food"
+-   [ ] Verify 200 status code
+-   [ ] Verify name updated, other fields preserved
+-   [ ] PUT /api/categories/999 (non-existent)
+-   [ ] Verify 404 status code
+-   [ ] Create second category "Entertainment"
+-   [ ] PUT /api/categories/1 with name "Entertainment"
+-   [ ] Verify 409 status code
+-   [ ] Verify CATEGORY_EXISTS error code
+-   [ ] PUT /api/categories/1 with name over 255 chars
+-   [ ] Verify 422 validation error
+-   [ ] DELETE /api/categories/1 (no transactions)
+-   [ ] Verify 204 status code
+-   [ ] Verify category deleted
+-   [ ] Create category and add transaction
+-   [ ] DELETE /api/categories/2
+-   [ ] Verify 409 status code
+-   [ ] Verify CATEGORY_HAS_TRANSACTIONS error code
+-   [ ] DELETE /api/categories/999 (non-existent)
+-   [ ] Verify 404 status code
+-   [ ] Run tests: `php artisan test --filter=CategoryControllerUpdateDeleteTest`
+
+## Notes
+
+-   Controller is interface layer - thin HTTP adapter
+-   Delegates all business logic to action services
+-   Update supports partial updates
+-   Update validates only provided fields
+-   Delete enforces business rule protection
+-   204 status returns no content
+-   Multiple exception types require careful handling
+-   Service layer enforces user isolation
+-   Cache invalidation handled by repository
+-   Response formats must match frontend expectations exactly
+-   Preserve unchanged fields in update
+-   Business rules enforced in domain layer
+
+## Related PRD Sections
+
+-   **Endpoint 4: Update Category:** Lines 301-333
+-   **Endpoint 5: Delete Category:** Lines 335-353
+-   **Validation Rules (Update):** Lines 315-319
+-   **Business Logic (Delete):** Lines 347-353
+-   **Error Handling:** Lines 606-623
+-   **Business Rule - Deletion Protection:** Lines 536-541
+-   **Layer Architecture - Interface Layer:** Lines 440-450
+-   **Exception Hierarchy:** Lines 595-603
+
+-   what should happen to transactions when their category is deleted?

--- a/.development-context/tickets/categories/TICKET-017.md
+++ b/.development-context/tickets/categories/TICKET-017.md
@@ -1,0 +1,245 @@
+# TICKET-017: API Routes Configuration
+
+**Estimate:** 1 hour  
+**Priority:** High  
+**Dependencies:** TICKET-014, TICKET-015, TICKET-016  
+**PRD Reference:** Lines 182-353, 670-676
+
+## Overview
+
+Register all category API routes in Laravel's routes/api.php file. Configure authentication middleware using Laravel Sanctum, apply proper route grouping, and ensure all five RESTful endpoints are accessible with correct HTTP methods per PRD specifications.
+
+## Technical Specifications
+
+### Routes Configuration
+
+Add to `routes/api.php`
+
+```php
+use App\Http\Controllers\CategoryController;
+
+Route::middleware('auth:sanctum')->group(function () {
+    // Category routes
+    Route::prefix('categories')->name('categories.')->group(function () {
+        Route::get('/', [CategoryController::class, 'index'])->name('index');
+        Route::post('/', [CategoryController::class, 'store'])->name('store');
+        Route::get('/{id}', [CategoryController::class, 'show'])->name('show');
+        Route::put('/{id}', [CategoryController::class, 'update'])->name('update');
+        Route::delete('/{id}', [CategoryController::class, 'destroy'])->name('destroy');
+    });
+});
+```
+
+### Alternative Resource Route Format
+
+```php
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('categories', CategoryController::class);
+});
+```
+
+### Route Specifications (PRD Lines 182-353)
+
+| Method | URI                  | Action  | Description                     |
+| ------ | -------------------- | ------- | ------------------------------- |
+| GET    | /api/categories      | index   | List categories with pagination |
+| POST   | /api/categories      | store   | Create new category             |
+| GET    | /api/categories/{id} | show    | Get single category             |
+| PUT    | /api/categories/{id} | update  | Update category                 |
+| DELETE | /api/categories/{id} | destroy | Delete category                 |
+
+### Middleware Configuration (PRD Lines 670-673)
+
+**Authentication:**
+
+-   Laravel Sanctum for API authentication
+-   Required for all category operations
+-   User-scoped operations only
+
+## Implementation Tasks
+
+1. Open `routes/api.php` file
+2. Add CategoryController use statement
+3. Create auth:sanctum middleware group
+4. Create categories prefix group
+5. Register GET /categories (index)
+6. Register POST /categories (store)
+7. Register GET /categories/{id} (show)
+8. Register PUT /categories/{id} (update)
+9. Register DELETE /categories/{id} (destroy)
+10. Add route names for testing
+11. Verify routes via artisan route:list
+12. Write route tests
+
+## Test Cases
+
+### Route Registration Tests
+
+```php
+describe('Category Routes Registration', function () {
+    it('registers GET /api/categories route');
+    it('registers POST /api/categories route');
+    it('registers GET /api/categories/{id} route');
+    it('registers PUT /api/categories/{id} route');
+    it('registers DELETE /api/categories/{id} route');
+    it('all routes prefixed with /api/categories');
+    it('all routes have named routes');
+});
+```
+
+### Route Method Tests
+
+```php
+describe('Category Routes HTTP Methods', function () {
+    it('index route accepts GET method only');
+    it('store route accepts POST method only');
+    it('show route accepts GET method only');
+    it('update route accepts PUT method only');
+    it('destroy route accepts DELETE method only');
+    it('rejects incorrect HTTP methods');
+});
+```
+
+### Authentication Middleware Tests
+
+```php
+describe('Category Routes Authentication', function () {
+    it('applies auth:sanctum middleware to all routes');
+    it('returns 401 when not authenticated on index');
+    it('returns 401 when not authenticated on store');
+    it('returns 401 when not authenticated on show');
+    it('returns 401 when not authenticated on update');
+    it('returns 401 when not authenticated on destroy');
+    it('allows access when authenticated');
+});
+```
+
+### Route Controller Binding Tests
+
+```php
+describe('Category Routes Controller Binding', function () {
+    it('binds index to CategoryController@index');
+    it('binds store to CategoryController@store');
+    it('binds show to CategoryController@show');
+    it('binds update to CategoryController@update');
+    it('binds destroy to CategoryController@destroy');
+});
+```
+
+### Route Parameter Tests
+
+```php
+describe('Category Routes Parameters', function () {
+    it('accepts id parameter in show route');
+    it('accepts id parameter in update route');
+    it('accepts id parameter in delete route');
+    it('accepts query parameters in index route');
+    it('passes parameters to controller correctly');
+});
+```
+
+### Route Naming Tests
+
+```php
+describe('Category Routes Naming', function () {
+    it('names index route as categories.index');
+    it('names store route as categories.store');
+    it('names show route as categories.show');
+    it('names update route as categories.update');
+    it('names destroy route as categories.destroy');
+    it('allows route generation via route() helper');
+});
+```
+
+### Integration Tests
+
+```php
+describe('Category Routes Integration', function () {
+    it('routes accessible via HTTP requests');
+    it('routes return proper responses');
+    it('routes integrate with controllers correctly');
+    it('middleware chain executes properly');
+    it('routes visible in route:list command');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('Category Routes Edge Cases', function () {
+    it('handles missing route parameters');
+    it('handles non-numeric id parameters');
+    it('handles very large id values');
+    it('handles trailing slashes');
+    it('rejects unsupported HTTP methods');
+});
+```
+
+### CORS Tests
+
+```php
+describe('Category Routes CORS', function () {
+    it('allows OPTIONS requests');
+    it('returns proper CORS headers');
+    it('handles preflight requests');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] All 5 routes registered in routes/api.php
+-   [ ] Routes prefixed with /api/categories
+-   [ ] auth:sanctum middleware applied to all routes
+-   [ ] Routes grouped properly
+-   [ ] Named routes configured
+-   [ ] Controller methods bound correctly
+-   [ ] ID parameter configured for show, update, destroy
+-   [ ] Routes visible in `php artisan route:list`
+-   [ ] Authentication required for all routes
+-   [ ] Routes accessible via HTTP
+-   [ ] 100% route test coverage
+-   [ ] All 35+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Run `php artisan route:list`
+-   [ ] Verify 5 category routes present
+-   [ ] Verify all routes show auth:sanctum middleware
+-   [ ] Verify correct HTTP methods
+-   [ ] Verify correct controller actions
+-   [ ] GET /api/categories without auth
+-   [ ] Verify 401 unauthorized response
+-   [ ] GET /api/categories with auth token
+-   [ ] Verify 200 success response
+-   [ ] POST /api/categories without auth
+-   [ ] Verify 401 unauthorized response
+-   [ ] GET /api/categories/1 with auth
+-   [ ] Verify 200 or 404 response
+-   [ ] PUT /api/categories/1 with auth
+-   [ ] Verify appropriate response
+-   [ ] DELETE /api/categories/1 with auth
+-   [ ] Verify appropriate response
+-   [ ] Run tests: `php artisan test --filter=CategoryRoutesTest`
+
+## Notes
+
+-   Routes defined in routes/api.php automatically get /api prefix
+-   auth:sanctum middleware validates Bearer tokens
+-   Route names useful for generating URLs in tests
+-   apiResource() provides cleaner syntax but less control
+-   Manual route definition provides explicit configuration
+-   Route model binding can be added later for automatic injection
+-   Middleware runs before controller methods
+-   CORS middleware should be configured in config/cors.php
+-   Rate limiting can be added via throttle middleware
+-   Route caching improves performance in production
+
+## Related PRD Sections
+
+-   **Endpoint 1: List Categories:** Lines 182-228
+-   **Endpoint 2: Create Category:** Lines 231-275
+-   **Endpoint 3: Get Category:** Lines 277-299
+-   **Endpoint 4: Update Category:** Lines 301-333
+-   **Endpoint 5: Delete Category:** Lines 335-353
+-   **Authentication:** Lines 670-673
+-   **Authorization:** Lines 674-676

--- a/.development-context/tickets/categories/TICKET-018.md
+++ b/.development-context/tickets/categories/TICKET-018.md
@@ -1,0 +1,329 @@
+# TICKET-018: Service Provider Bindings
+
+**Estimate:** 2 hours  
+**Priority:** Critical  
+**Dependencies:** TICKET-006, TICKET-008 through TICKET-012  
+**PRD Reference:** Lines 404-485
+
+## Overview
+
+Configure Laravel's service container bindings in AppServiceProvider to wire up the dependency injection for the Categories domain. Register repository interface implementation and all use case service bindings to enable constructor injection throughout the application per PRD specifications.
+
+## Technical Specifications
+
+### Service Provider Location
+
+`app/Providers/AppServiceProvider.php`
+
+### Service Provider Structure
+
+```php
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Domains\Categories\Repositories\ICategoryRepository;
+use App\Domains\Categories\Infrastructure\Repositories\CategoryRepository;
+use App\Domains\Categories\Actions\{
+    IndexCategoriesService,
+    ShowCategoryAction,
+    StoreCategoryAction,
+    UpdateCategoryAction,
+    DeleteCategoryAction
+};
+use App\Domains\Categories\Infrastructure\Mappers\CategoryMapper;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        // Repository binding (Singleton)
+        $this->app->singleton(ICategoryRepository::class, function ($app) {
+            return new CategoryRepository(
+                $app->make('db'),
+                $app->make('redis')
+            );
+        });
+
+        // Mapper binding (Singleton)
+        $this->app->singleton(CategoryMapper::class, function ($app) {
+            return new CategoryMapper();
+        });
+
+        // Use Case Service bindings (Transient)
+        $this->app->bind(IndexCategoriesService::class, function ($app) {
+            return new IndexCategoriesService(
+                $app->make(ICategoryRepository::class),
+                $app->make(CategoryMapper::class)
+            );
+        });
+
+        $this->app->bind(ShowCategoryAction::class, function ($app) {
+            return new ShowCategoryAction(
+                $app->make(ICategoryRepository::class),
+                $app->make(CategoryMapper::class)
+            );
+        });
+
+        $this->app->bind(StoreCategoryAction::class, function ($app) {
+            return new StoreCategoryAction(
+                $app->make(ICategoryRepository::class),
+                $app->make(CategoryMapper::class)
+            );
+        });
+
+        $this->app->bind(UpdateCategoryAction::class, function ($app) {
+            return new UpdateCategoryAction(
+                $app->make(ICategoryRepository::class),
+                $app->make(CategoryMapper::class)
+            );
+        });
+
+        $this->app->bind(DeleteCategoryAction::class, function ($app) {
+            return new DeleteCategoryAction(
+                $app->make(ICategoryRepository::class)
+            );
+        });
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}
+```
+
+### Binding Specifications (PRD Lines 467-484)
+
+**Singleton Bindings:**
+
+-   ICategoryRepository → CategoryRepository (shared instance)
+-   CategoryMapper → CategoryMapper (shared instance)
+
+**Transient Bindings:**
+
+-   IndexCategoriesService (new instance per resolution)
+-   ShowCategoryAction (new instance per resolution)
+-   StoreCategoryAction (new instance per resolution)
+-   UpdateCategoryAction (new instance per resolution)
+-   DeleteCategoryAction (new instance per resolution)
+
+### Dependency Graph
+
+```
+CategoryController
+├── IndexCategoriesService
+│   ├── ICategoryRepository (singleton)
+│   └── CategoryMapper (singleton)
+├── ShowCategoryAction
+│   ├── ICategoryRepository (singleton)
+│   └── CategoryMapper (singleton)
+├── StoreCategoryAction
+│   ├── ICategoryRepository (singleton)
+│   └── CategoryMapper (singleton)
+├── UpdateCategoryAction
+│   ├── ICategoryRepository (singleton)
+│   └── CategoryMapper (singleton)
+└── DeleteCategoryAction
+    └── ICategoryRepository (singleton)
+```
+
+## Implementation Tasks
+
+1. Open `app/Providers/AppServiceProvider.php`
+2. Add use statements for all classes
+3. Register ICategoryRepository → CategoryRepository singleton
+4. Configure repository with DB and Redis dependencies
+5. Register CategoryMapper singleton
+6. Register IndexCategoriesService transient binding
+7. Register ShowCategoryAction transient binding
+8. Register StoreCategoryAction transient binding
+9. Register UpdateCategoryAction transient binding
+10. Register DeleteCategoryAction transient binding
+11. Verify dependency resolution
+12. Write binding tests
+
+## Test Cases
+
+### Repository Binding Tests
+
+```php
+describe('Service Provider Repository Bindings', function () {
+    it('binds ICategoryRepository to CategoryRepository');
+    it('resolves ICategoryRepository as singleton');
+    it('returns same instance on multiple resolutions');
+    it('injects DB connection into repository');
+    it('injects Redis connection into repository');
+    it('repository is instance of ICategoryRepository');
+    it('repository is instance of CategoryRepository');
+});
+```
+
+### Mapper Binding Tests
+
+```php
+describe('Service Provider Mapper Bindings', function () {
+    it('binds CategoryMapper as singleton');
+    it('resolves CategoryMapper correctly');
+    it('returns same instance on multiple resolutions');
+});
+```
+
+### Use Case Service Binding Tests
+
+```php
+describe('Service Provider Use Case Bindings', function () {
+    it('resolves IndexCategoriesService');
+    it('resolves ShowCategoryAction');
+    it('resolves StoreCategoryAction');
+    it('resolves UpdateCategoryAction');
+    it('resolves DeleteCategoryAction');
+    it('creates new instance each time for services');
+    it('injects repository into all services');
+    it('injects mapper into services that need it');
+});
+```
+
+### Dependency Injection Tests
+
+```php
+describe('Service Provider Dependency Injection', function () {
+    it('resolves repository dependency in IndexCategoriesService');
+    it('resolves repository dependency in ShowCategoryAction');
+    it('resolves repository dependency in StoreCategoryAction');
+    it('resolves repository dependency in UpdateCategoryAction');
+    it('resolves repository dependency in DeleteCategoryAction');
+    it('resolves mapper dependency in services');
+    it('all dependencies auto-resolve');
+});
+```
+
+### Controller Injection Tests
+
+```php
+describe('Service Provider Controller Injection', function () {
+    it('resolves CategoryController');
+    it('injects IndexCategoriesService into controller');
+    it('injects ShowCategoryAction into controller');
+    it('injects StoreCategoryAction into controller');
+    it('injects UpdateCategoryAction into controller');
+    it('injects DeleteCategoryAction into controller');
+    it('controller receives all dependencies');
+});
+```
+
+### Singleton Behavior Tests
+
+```php
+describe('Service Provider Singleton Behavior', function () {
+    it('repository instance is shared across services');
+    it('mapper instance is shared across services');
+    it('repository maintains state between resolutions');
+    it('same repository instance in all services');
+});
+```
+
+### Circular Dependency Tests
+
+```php
+describe('Service Provider Circular Dependencies', function () {
+    it('has no circular dependencies');
+    it('dependency graph is acyclic');
+    it('all dependencies can resolve');
+});
+```
+
+### Binding Scope Tests
+
+```php
+describe('Service Provider Binding Scopes', function () {
+    it('uses singleton for repository');
+    it('uses singleton for mapper');
+    it('uses transient for services');
+    it('respects binding scopes correctly');
+});
+```
+
+### Integration Tests
+
+```php
+describe('Service Provider Integration', function () {
+    it('all bindings work together');
+    it('enables full CRUD operations');
+    it('resolves entire dependency tree');
+    it('services can access repository methods');
+    it('no runtime binding errors');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('Service Provider Edge Cases', function () {
+    it('handles binding before boot');
+    it('handles multiple provider registrations');
+    it('handles missing dependencies gracefully');
+    it('bindings available in all contexts');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] AppServiceProvider updated with bindings
+-   [ ] ICategoryRepository bound to CategoryRepository
+-   [ ] Repository registered as singleton
+-   [ ] CategoryMapper registered as singleton
+-   [ ] All 5 use case services registered as transient
+-   [ ] DB and Redis injected into repository
+-   [ ] Repository and mapper injected into services
+-   [ ] All dependencies resolve correctly
+-   [ ] No circular dependencies
+-   [ ] Singleton vs transient scopes correct
+-   [ ] Controller can resolve with all services
+-   [ ] 100% test coverage
+-   [ ] All 40+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Run `php artisan tinker`
+-   [ ] Execute: `app(App\Domains\Categories\Repositories\ICategoryRepository::class)`
+-   [ ] Verify CategoryRepository instance returned
+-   [ ] Execute again and verify same instance (singleton)
+-   [ ] Execute: `app(App\Domains\Categories\Actions\IndexCategoriesService::class)`
+-   [ ] Verify service resolved with dependencies
+-   [ ] Verify repository property is set
+-   [ ] Verify mapper property is set
+-   [ ] Execute: `app(App\Http\Controllers\CategoryController::class)`
+-   [ ] Verify controller resolved with all 5 services
+-   [ ] Create category via API
+-   [ ] Verify dependency injection works end-to-end
+-   [ ] Run tests: `php artisan test --filter=ServiceProviderBindingsTest`
+
+## Notes
+
+-   AppServiceProvider is loaded on every request
+-   Singleton bindings create one instance per application lifecycle
+-   Transient bindings create new instance per resolution
+-   Repository should be singleton for cache sharing
+-   Services should be transient to avoid state issues
+-   Closure-based binding allows explicit dependency control
+-   Automatic resolution works when type-hints match bindings
+-   Container can auto-resolve concrete classes without bindings
+-   Explicit bindings document dependencies clearly
+-   Bindings enable easy testing via mocking
+-   Use `app()->bind()` for transient, `app()->singleton()` for singletons
+-   Verify no circular dependencies exist
+
+## Related PRD Sections
+
+-   **Dependency Injection:** Lines 464-485
+-   **Service Bindings:** Lines 467-475 (repository)
+-   **Action/Service Bindings:** Lines 478-484
+-   **Layer Architecture:** Lines 404-450
+-   **Repository Pattern:** Lines 412-414
+-   **Use Cases (Actions):** Lines 418-425

--- a/.development-context/tickets/categories/TICKET-019.md
+++ b/.development-context/tickets/categories/TICKET-019.md
@@ -1,0 +1,417 @@
+# TICKET-019: Integration Tests - CRUD Flow
+
+**Estimate:** 4-5 hours  
+**Priority:** High  
+**Dependencies:** TICKET-014, TICKET-015, TICKET-016, TICKET-017  
+**PRD Reference:** Lines 627-665, 34-57
+
+## Overview
+
+Create comprehensive integration test suite that validates the complete CRUD flow for categories through the API layer. Tests should cover happy paths, authentication requirements, validation errors, business rule violations, and end-to-end workflows per PRD specifications.
+
+## Technical Specifications
+
+### Test File Location
+
+`tests/Feature/CategoryCRUDTest.php`
+
+### Test Framework
+
+-   PHPUnit with Pest syntax
+-   Laravel testing utilities
+-   Database transactions for isolation
+-   Sanctum authentication
+
+### Test Structure Template
+
+```php
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('Category CRUD Integration', function () {
+    // Test cases here
+});
+```
+
+## Implementation Tasks
+
+1. Create Feature test file
+2. Set up database transactions
+3. Create user factory for authentication
+4. Implement full CRUD flow test
+5. Write authentication tests
+6. Write validation error tests
+7. Write business rule violation tests
+8. Write user isolation tests
+9. Set up test database seeding
+10. Add cleanup and teardown
+
+## Test Cases
+
+### Complete CRUD Flow Tests
+
+```php
+describe('Category Complete CRUD Flow', function () {
+    it('completes full CRUD lifecycle successfully', function () {
+        // Arrange: Authenticate user
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Act & Assert: Create
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->postJson('/api/categories', [
+            'name' => 'Groceries',
+            'type' => 'expense',
+            'notes' => 'Food and household'
+        ]);
+
+        $response->assertStatus(201);
+        $categoryId = $response->json('data.id');
+
+        // Act & Assert: Read (Index)
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->getJson('/api/categories');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.0.name', 'Groceries');
+
+        // Act & Assert: Read (Show)
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->getJson("/api/categories/{$categoryId}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'Groceries');
+
+        // Act & Assert: Update
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->putJson("/api/categories/{$categoryId}", [
+            'name' => 'Food'
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'Food');
+
+        // Act & Assert: Delete
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->deleteJson("/api/categories/{$categoryId}");
+
+        $response->assertStatus(204);
+
+        // Verify deletion
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->getJson("/api/categories/{$categoryId}");
+
+        $response->assertStatus(404);
+    });
+
+    it('maintains data consistency throughout CRUD operations');
+    it('handles rapid successive CRUD operations');
+    it('preserves unchanged fields during updates');
+    it('enforces all business rules during flow');
+});
+```
+
+### Authentication Requirement Tests
+
+```php
+describe('Category CRUD Authentication', function () {
+    it('requires authentication for index', function () {
+        $response = $this->getJson('/api/categories');
+        $response->assertStatus(401);
+    });
+
+    it('requires authentication for store', function () {
+        $response = $this->postJson('/api/categories', [
+            'name' => 'Test',
+            'type' => 'expense'
+        ]);
+        $response->assertStatus(401);
+    });
+
+    it('requires authentication for show', function () {
+        $response = $this->getJson('/api/categories/1');
+        $response->assertStatus(401);
+    });
+
+    it('requires authentication for update', function () {
+        $response = $this->putJson('/api/categories/1', [
+            'name' => 'Updated'
+        ]);
+        $response->assertStatus(401);
+    });
+
+    it('requires authentication for destroy', function () {
+        $response = $this->deleteJson('/api/categories/1');
+        $response->assertStatus(401);
+    });
+
+    it('accepts valid Bearer token');
+    it('rejects invalid Bearer token');
+    it('rejects expired token');
+    it('associates created categories with authenticated user');
+});
+```
+
+### Validation Error Tests
+
+```php
+describe('Category CRUD Validation Errors', function () {
+    it('returns 422 when creating without name', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->postJson('/api/categories', [
+            'type' => 'expense'
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
+    });
+
+    it('returns 422 when creating without type');
+    it('returns 422 when name exceeds 255 characters');
+    it('returns 422 when notes exceed 1000 characters');
+    it('returns 422 when type is invalid');
+    it('returns 422 when updating with invalid data');
+    it('returns 422 for invalid pagination parameters');
+    it('returns validation errors with proper structure');
+    it('returns multiple validation errors when multiple fields invalid');
+    it('includes error messages in validation response');
+});
+```
+
+### Business Rule Violation Tests
+
+```php
+describe('Category CRUD Business Rule Violations', function () {
+    it('returns 409 when creating duplicate category name', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Create first category
+        $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->postJson('/api/categories', [
+            'name' => 'Groceries',
+            'type' => 'expense'
+        ])->assertStatus(201);
+
+        // Attempt duplicate
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->postJson('/api/categories', [
+            'name' => 'Groceries',
+            'type' => 'income'
+        ]);
+
+        $response->assertStatus(409)
+            ->assertJsonPath('error.code', 'CATEGORY_EXISTS');
+    });
+
+    it('returns 409 when updating to existing name');
+    it('returns 409 when deleting category with transactions');
+    it('allows same name for different users');
+    it('enforces name uniqueness case-sensitively');
+    it('prevents deletion of categories with recurring transactions');
+});
+```
+
+### Pagination and Filtering Tests
+
+```php
+describe('Category CRUD Pagination and Filtering', function () {
+    it('paginates categories correctly', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Create 25 categories
+        for ($i = 1; $i <= 25; $i++) {
+            $this->withHeaders([
+                'Authorization' => "Bearer $token"
+            ])->postJson('/api/categories', [
+                'name' => "Category $i",
+                'type' => $i % 2 === 0 ? 'income' : 'expense'
+            ]);
+        }
+
+        // Test pagination
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token"
+        ])->getJson('/api/categories?page=1&limit=10');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(10, 'data')
+            ->assertJsonPath('pagination.currentPage', 1)
+            ->assertJsonPath('pagination.itemsPerPage', 10)
+            ->assertJsonPath('pagination.totalItems', 25);
+    });
+
+    it('filters by income type');
+    it('filters by expense type');
+    it('returns correct page of results');
+    it('handles page beyond available pages');
+    it('respects limit parameter');
+    it('defaults to page 1 and limit 20');
+});
+```
+
+### User Isolation Tests
+
+```php
+describe('Category CRUD User Isolation', function () {
+    it('only returns categories for authenticated user', function () {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $token1 = $user1->createToken('test')->plainTextToken;
+        $token2 = $user2->createToken('test')->plainTextToken;
+
+        // User 1 creates category
+        $this->withHeaders([
+            'Authorization' => "Bearer $token1"
+        ])->postJson('/api/categories', [
+            'name' => 'User1 Category',
+            'type' => 'expense'
+        ]);
+
+        // User 2 should not see User 1's category
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer $token2"
+        ])->getJson('/api/categories');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    });
+
+    it('cannot access another users category by ID');
+    it('cannot update another users category');
+    it('cannot delete another users category');
+    it('allows duplicate names across different users');
+    it('isolates all operations by user');
+});
+```
+
+### Response Format Tests
+
+```php
+describe('Category CRUD Response Formats', function () {
+    it('returns correct format for index');
+    it('returns correct format for store');
+    it('returns correct format for show');
+    it('returns correct format for update');
+    it('returns empty content for destroy');
+    it('includes all required fields in responses');
+    it('formats dates as ISO 8601');
+    it('uses camelCase for property names');
+    it('includes pagination metadata in index');
+    it('wraps single resources in data key');
+    it('wraps collections in data key');
+});
+```
+
+### Error Handling Tests
+
+```php
+describe('Category CRUD Error Handling', function () {
+    it('returns 404 for non-existent category show');
+    it('returns 404 for non-existent category update');
+    it('returns 404 for non-existent category delete');
+    it('returns proper error structure for all errors');
+    it('includes error message and code');
+    it('handles database connection errors gracefully');
+    it('handles validation errors gracefully');
+    it('maintains data integrity on errors');
+});
+```
+
+### Edge Case Tests
+
+```php
+describe('Category CRUD Edge Cases', function () {
+    it('handles creating category with minimal data');
+    it('handles creating category with all fields');
+    it('handles updating with no changes');
+    it('handles empty query results');
+    it('handles special characters in names');
+    it('handles unicode characters in names');
+    it('handles very long valid names');
+    it('handles rapid successive operations');
+    it('handles concurrent requests');
+});
+```
+
+### Cache Behavior Tests
+
+```php
+describe('Category CRUD Cache Behavior', function () {
+    it('invalidates cache after create');
+    it('invalidates cache after update');
+    it('invalidates cache after delete');
+    it('serves cached data on subsequent reads');
+    it('cache reflects latest data after mutations');
+});
+```
+
+## Acceptance Criteria
+
+-   [ ] Integration test suite created
+-   [ ] Uses RefreshDatabase trait
+-   [ ] Full CRUD flow test passes
+-   [ ] All authentication tests pass
+-   [ ] All validation error tests pass
+-   [ ] All business rule tests pass
+-   [ ] All user isolation tests pass
+-   [ ] All pagination tests pass
+-   [ ] All response format tests pass
+-   [ ] All error handling tests pass
+-   [ ] All edge case tests pass
+-   [ ] Tests use test database
+-   [ ] Tests clean up after themselves
+-   [ ] 100% integration test coverage
+-   [ ] All 70+ test cases pass
+
+## Validation Checklist
+
+-   [ ] Run `php artisan test --filter=CategoryCRUDTest`
+-   [ ] Verify all tests pass
+-   [ ] Verify database is refreshed between tests
+-   [ ] Run with --coverage flag
+-   [ ] Verify 100% code coverage for integration paths
+-   [ ] Run tests multiple times for consistency
+-   [ ] Verify no flaky tests
+-   [ ] Check test execution time (should be < 10 seconds)
+
+## Notes
+
+-   Use RefreshDatabase trait for clean test state
+-   Use factories for test data generation
+-   Use Sanctum for test authentication
+-   Each test should be isolated and independent
+-   Use descriptive test names
+-   Follow Arrange-Act-Assert pattern
+-   Test both happy paths and error paths
+-   Verify database state after operations
+-   Use JSON assertions for API responses
+-   Test user isolation thoroughly
+-   Verify cache behavior
+-   Keep tests fast and focused
+
+## Related PRD Sections
+
+-   **Testing Strategy:** Lines 627-665
+-   **API Endpoint Tests:** Lines 649-655
+-   **Database Tests:** Lines 656-660
+-   **Cache Tests:** Lines 661-665
+-   **Success Metrics:** Lines 42-48
+-   **All API Endpoints:** Lines 182-353

--- a/.development-context/tickets/categories/TICKET-020.md
+++ b/.development-context/tickets/categories/TICKET-020.md
@@ -1,0 +1,29 @@
+# TICKET-020: Integration Tests - Cache Behavior
+
+**Estimate:** 3-4 hours  
+**Priority:** Medium  
+**Dependencies:** TICKET-019
+
+## Tasks
+
+-   Test cache hits on read operations
+-   Test cache invalidation on create
+-   Test cache invalidation on update
+-   Test cache invalidation on delete
+-   Test cache key patterns
+
+## Acceptance Criteria
+
+-   Cache hit/miss behavior correct
+-   Invalidation triggers work
+-   Cache TTL respected
+-   All cache tests pass
+
+-   how should categories be cached?
+
+create transaction form
+update trandaction form
+
+transaction filters ui
+
+id and slug, name,

--- a/.development-context/tickets/categories/TICKET-021.md
+++ b/.development-context/tickets/categories/TICKET-021.md
@@ -1,0 +1,19 @@
+# TICKET-021: API Documentation
+
+**Estimate:** 2-3 hours  
+**Priority:** Medium  
+**Dependencies:** TICKET-017
+
+## Tasks
+
+-   Update `docs/API.md` with category endpoints
+-   Update `docs/openapi.yaml` with category spec
+-   Document request/response examples
+-   Document error responses
+
+## Acceptance Criteria
+
+-   All 5 endpoints documented
+-   Examples match PRD
+-   OpenAPI spec valid
+-   Error codes documented

--- a/.development-context/tickets/categories/TICKET-022.md
+++ b/.development-context/tickets/categories/TICKET-022.md
@@ -1,0 +1,20 @@
+# TICKET-022: Performance Testing
+
+**Estimate:** 3-4 hours  
+**Priority:** Medium  
+**Dependencies:** TICKET-019
+
+## Tasks
+
+-   Create performance test suite
+-   Test response times < 50ms (95th percentile)
+-   Test cache effectiveness (95% hit rate)
+-   Test pagination performance
+-   Document benchmark results
+
+## Acceptance Criteria
+
+-   API responses under 50ms target
+-   Cache hit rate meets 95% target
+-   Performance benchmarks documented
+-   No N+1 queries

--- a/.development-context/tickets/categories/TICKET-023.md
+++ b/.development-context/tickets/categories/TICKET-023.md
@@ -1,0 +1,19 @@
+# TICKET-023: Error Handling & Logging
+
+**Estimate:** 2-3 hours  
+**Priority:** High  
+**Dependencies:** TICKET-014, TICKET-015, TICKET-016
+
+## Tasks
+
+-   Ensure all exceptions logged properly
+-   Verify error response format (lines 612-623)
+-   Test all error scenarios
+-   Add contextual logging
+
+## Acceptance Criteria
+
+-   All exceptions caught and formatted
+-   Error format matches PRD
+-   Proper HTTP status codes
+-   Logs contain context

--- a/.development-context/tickets/categories/TICKET-024.md
+++ b/.development-context/tickets/categories/TICKET-024.md
@@ -1,0 +1,21 @@
+# TICKET-024: Code Review & Cleanup
+
+**Estimate:** 2-3 hours  
+**Priority:** Medium  
+**Dependencies:** All previous tickets
+
+## Tasks
+
+-   Review all code for DRY principles
+-   Add PHPDoc blocks
+-   Check PSR-12 compliance
+-   Run PHPStan analysis
+-   Fix any linter errors
+
+## Acceptance Criteria
+
+-   No PHPStan errors
+-   PSR-12 compliant
+-   All classes documented
+-   No code duplication
+-   Follows memory preferences

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,623 @@
+# Contributing to Junction Bank
+
+## Development Workflow
+
+### Branch Strategy
+
+```
+main (laravel-v1)
+  ├── feature/TICKET-123-description
+  ├── bugfix/TICKET-456-description
+  └── refactor/TICKET-789-description
+```
+
+**Branch Naming:**
+
+-   `feature/` - New functionality
+-   `bugfix/` - Bug fixes
+-   `refactor/` - Code improvements
+-   `hotfix/` - Production emergency fixes
+
+### Commit Guidelines
+
+**Format:**
+
+```
+type(scope): brief description
+
+Detailed explanation if needed.
+
+Refs: TICKET-123
+```
+
+**Types:**
+
+-   `feat` - New feature
+-   `fix` - Bug fix
+-   `refactor` - Code refactoring
+-   `test` - Test updates
+-   `docs` - Documentation
+-   `chore` - Maintenance tasks
+-   `perf` - Performance improvements
+
+**Examples:**
+
+```bash
+feat(categories): add bulk category import
+fix(transactions): resolve date parsing error
+refactor(auth): extract token validation logic
+test(categories): add repository unit tests
+docs(api): update authentication flow
+```
+
+### Pull Request Process
+
+1. **Create branch from main**
+
+    ```bash
+    git checkout main
+    git pull origin main
+    git checkout -b feature/TICKET-123-add-feature
+    ```
+
+2. **Develop with quality checks**
+
+    ```bash
+    # Make changes
+    just pint              # Fix code style
+    just phpstan           # Static analysis
+    just test              # Run tests
+    ```
+
+3. **Commit changes**
+
+    ```bash
+    git add .
+    git commit -m "feat(domain): description"
+    ```
+
+4. **Push and create PR**
+
+    ```bash
+    git push origin feature/TICKET-123-add-feature
+    ```
+
+5. **PR Requirements**
+
+    - All tests passing
+    - PHPStan clean
+    - Code style compliant
+    - Architecture tests passing
+    - Review approved
+
+6. **Merge**
+    - Use squash and merge for features
+    - Use rebase for bugfixes
+    - Delete branch after merge
+
+## Code Standards
+
+### PHP Standards
+
+**PSR-12 Compliance:**
+
+-   Enforced by Laravel Pint
+-   Run `just pint` before committing
+
+**Type Safety:**
+
+-   Strict types enabled
+-   Type hints required
+-   Return types required
+-   Property types required (PHP 7.4+)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Categories\Actions;
+
+use App\Domains\Categories\DTOs\CategoryData;
+use App\Domains\Categories\Models\Category;
+use App\Domains\Categories\Repositories\CategoryRepository;
+
+final class CreateCategoryAction
+{
+    public function __construct(
+        private readonly CategoryRepository $repository
+    ) {}
+
+    public function execute(CategoryData $data): Category
+    {
+        return $this->repository->create($data);
+    }
+}
+```
+
+**PHPStan Level:**
+
+-   Level 8 (maximum)
+-   Run `just phpstan` regularly
+
+### Domain-Driven Design Principles
+
+**1. Thin Controllers**
+
+Controllers delegate to Actions:
+
+```php
+// Good
+public function store(CreateCategoryRequest $request): JsonResponse
+{
+    $category = $this->createCategory->execute(
+        CategoryData::fromRequest($request)
+    );
+
+    return response()->json($category, 201);
+}
+
+// Bad - business logic in controller
+public function store(CreateCategoryRequest $request): JsonResponse
+{
+    $category = Category::create([
+        'name' => $request->name,
+        'type' => $request->type,
+    ]);
+
+    return response()->json($category, 201);
+}
+```
+
+**2. Actions Contain Business Logic**
+
+```php
+final class CreateCategoryAction
+{
+    public function __construct(
+        private readonly CategoryRepository $repository,
+        private readonly CategoryValidator $validator
+    ) {}
+
+    public function execute(CategoryData $data): Category
+    {
+        $this->validator->validate($data);
+
+        return $this->repository->create($data);
+    }
+}
+```
+
+**3. Repository Pattern**
+
+Abstract data access:
+
+```php
+interface CategoryRepository
+{
+    public function create(CategoryData $data): Category;
+    public function find(int $id): ?Category;
+    public function findAll(): Collection;
+    public function update(int $id, CategoryData $data): Category;
+    public function delete(int $id): bool;
+}
+```
+
+**4. DTOs for Data Transfer**
+
+```php
+final readonly class CategoryData
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public ?string $description = null
+    ) {}
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            name: $request->string('name')->toString(),
+            type: $request->string('type')->toString(),
+            description: $request->string('description')->toString()
+        );
+    }
+}
+```
+
+**5. Domain Isolation**
+
+Each domain is self-contained:
+
+-   No cross-domain model imports
+-   Use DTOs for inter-domain communication
+-   Repository interfaces define contracts
+
+### File Organization
+
+**Domain Structure:**
+
+```
+app/Domains/{DomainName}/
+├── Actions/
+│   ├── CreateCategoryAction.php
+│   ├── UpdateCategoryAction.php
+│   └── DeleteCategoryAction.php
+├── DTOs/
+│   ├── CategoryData.php
+│   └── CategoryFilterData.php
+├── Models/
+│   └── Category.php
+├── Repositories/
+│   ├── CategoryRepository.php
+│   └── EloquentCategoryRepository.php
+├── Policies/
+│   └── CategoryPolicy.php
+└── Http/
+    ├── Requests/
+    │   ├── CreateCategoryRequest.php
+    │   └── UpdateCategoryRequest.php
+    └── Controllers/
+        └── CategoryController.php
+```
+
+**Naming Conventions:**
+
+-   Actions: `{Verb}{Noun}Action.php`
+-   DTOs: `{Noun}Data.php`
+-   Repositories: `{Noun}Repository.php` (interface), `Eloquent{Noun}Repository.php` (implementation)
+-   Requests: `{Verb}{Noun}Request.php`
+-   Controllers: `{Noun}Controller.php`
+
+### Testing Standards
+
+**Test Structure:**
+
+```
+tests/
+├── Unit/
+│   └── Domains/
+│       └── Categories/
+│           ├── Actions/
+│           ├── DTOs/
+│           └── Repositories/
+├── Feature/
+│   └── Domains/
+│       └── Categories/
+│           └── Http/
+│               └── Controllers/
+└── Architecture/
+    └── DomainTest.php
+```
+
+**Test Naming:**
+
+```php
+it('creates a category with valid data', function () {
+    // Arrange
+    $data = CategoryData::from([
+        'name' => 'Groceries',
+        'type' => 'expense',
+    ]);
+
+    // Act
+    $category = $this->action->execute($data);
+
+    // Assert
+    expect($category)->toBeInstanceOf(Category::class);
+    expect($category->name)->toBe('Groceries');
+});
+```
+
+**Coverage Requirements:**
+
+-   Unit tests: 90%+
+-   Feature tests: Critical paths
+-   Architecture tests: Domain rules
+
+**Before Committing:**
+
+```bash
+just test              # All tests
+just phpstan           # Static analysis
+just pint-test         # Style check
+```
+
+## Development Environment
+
+### Initial Setup
+
+```bash
+# Clone and setup
+git clone <repo>
+cd junction-bank
+just setup
+
+# Verify
+just health
+```
+
+### Daily Workflow
+
+```bash
+# Start environment
+just dev
+
+# Pull latest changes
+git checkout main
+git pull origin main
+
+# Create feature branch
+git checkout -b feature/TICKET-123-description
+
+# Make changes
+# Run quality checks
+just quality
+
+# Commit
+git add .
+git commit -m "feat(domain): description"
+
+# Push
+git push origin feature/TICKET-123-description
+
+# Stop environment (end of day)
+just dev-stop
+```
+
+### Common Tasks
+
+**Database:**
+
+```bash
+just migrate           # Run new migrations
+just migrate-fresh     # Reset database
+just seed              # Run seeders
+just db-backup         # Backup before risky changes
+just psql              # Database CLI
+```
+
+**Debugging:**
+
+```bash
+just dev-logs          # View all logs
+just dev-logs php      # View PHP logs
+just ssh               # SSH into PHP container
+just artisan tinker    # Laravel REPL
+```
+
+**Cache:**
+
+```bash
+just clean-cache       # Clear all caches
+just artisan cache:clear
+```
+
+## Code Review Guidelines
+
+### As Author
+
+**Before Creating PR:**
+
+1. Self-review changes
+2. Run `just quality`
+3. Run `just test`
+4. Update tests
+5. Update documentation
+6. Write clear PR description
+
+**PR Description Template:**
+
+```markdown
+## Description
+
+Brief description of changes.
+
+## Changes
+
+-   Added X
+-   Modified Y
+-   Removed Z
+
+## Testing
+
+-   [ ] Unit tests added/updated
+-   [ ] Feature tests added/updated
+-   [ ] Manual testing completed
+
+## Checklist
+
+-   [ ] Code style compliant (just pint)
+-   [ ] Static analysis clean (just phpstan)
+-   [ ] All tests passing (just test)
+-   [ ] Documentation updated
+-   [ ] No breaking changes (or documented)
+
+Refs: TICKET-123
+```
+
+### As Reviewer
+
+**Review Checklist:**
+
+-   [ ] Code follows DDD principles
+-   [ ] Controllers are thin
+-   [ ] Actions contain business logic
+-   [ ] Repository pattern used
+-   [ ] DTOs used for data transfer
+-   [ ] Type hints present
+-   [ ] Tests cover changes
+-   [ ] No obvious security issues
+-   [ ] Performance considerations
+-   [ ] Error handling appropriate
+
+**Review Tone:**
+
+-   Be constructive
+-   Explain "why" in feedback
+-   Approve when standards met
+-   Request changes for violations
+
+## Architecture Decisions
+
+All significant architecture decisions must be documented as ADRs.
+
+**ADR Template:**
+
+```markdown
+# ADR-NNN: Title
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded
+
+## Context
+
+What problem are we solving?
+
+## Decision
+
+What did we decide?
+
+## Consequences
+
+What are the tradeoffs?
+
+## Alternatives Considered
+
+What else did we consider?
+```
+
+**Location:** `.development-context/ADRs/NNN-title.md`
+
+## Documentation Standards
+
+**Code Comments:**
+
+```php
+/**
+ * Create a new category.
+ *
+ * @param CategoryData $data The category data
+ * @return Category The created category
+ * @throws ValidationException When data is invalid
+ */
+public function execute(CategoryData $data): Category
+{
+    // Validate category doesn't already exist
+    if ($this->repository->existsByName($data->name)) {
+        throw ValidationException::withMessages([
+            'name' => 'Category already exists',
+        ]);
+    }
+
+    return $this->repository->create($data);
+}
+```
+
+**README Updates:**
+
+-   Update when adding features
+-   Update when changing setup
+-   Keep examples current
+
+**API Documentation:**
+
+-   Document all public endpoints
+-   Include request/response examples
+-   Document error responses
+
+## Performance Guidelines
+
+**Database:**
+
+-   Use eager loading (`with()`)
+-   Index foreign keys
+-   Avoid N+1 queries
+-   Use database transactions
+
+**Caching:**
+
+-   Cache expensive queries
+-   Use Redis for sessions
+-   Cache configuration in production
+
+**Optimization:**
+
+-   Profile before optimizing
+-   Use Laravel Debugbar in development
+-   Monitor query counts
+
+## Security Guidelines
+
+**Input Validation:**
+
+-   Use Form Requests
+-   Validate all user input
+-   Sanitize output
+
+**Authentication:**
+
+-   Use Laravel Sanctum
+-   Implement rate limiting
+-   Secure API tokens
+
+**Authorization:**
+
+-   Use Policies
+-   Check permissions in controllers
+-   Fail closed (deny by default)
+
+**Data Protection:**
+
+-   Never commit secrets
+-   Use environment variables
+-   Encrypt sensitive data
+
+## Troubleshooting
+
+**Tests Failing:**
+
+```bash
+just clean              # Clean environment
+just setup              # Fresh setup
+just test               # Retry
+```
+
+**Permission Errors:**
+
+```bash
+echo "USER_ID=$(id -u)" >> .env
+echo "GROUP_ID=$(id -g)" >> .env
+just build-dev
+```
+
+**Database Issues:**
+
+```bash
+just migrate-fresh      # Reset database
+just db-backup          # Backup if needed
+just psql               # Check connection
+```
+
+**Style/Stan Errors:**
+
+```bash
+just pint               # Auto-fix style
+just phpstan --verbose  # Detailed errors
+```
+
+## Resources
+
+-   [Domain-Driven Design Rules](.development-context/rules/01-domain-driven-design.md)
+-   [Repository Pattern](.development-context/rules/02-repository-pattern.md)
+-   [API Routes Delegation](.development-context/rules/04-api-routes-delegate-to-actions.md)
+-   [Docker Architecture](docker/README.md)
+-   [Architecture Decisions](.development-context/ADRs/)
+
+## Questions?
+
+1. Check `.development-context/` documentation
+2. Review existing domain implementations
+3. Check architecture tests for examples
+4. Run `just health` for diagnostics

--- a/README.md
+++ b/README.md
@@ -1,61 +1,305 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Junction Bank
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Domain-driven personal finance management system built with Laravel, Next.js, and PostgreSQL.
 
-## About Laravel
+## Architecture
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+```mermaid
+graph TB
+    subgraph "Client"
+        Next[Next.js Frontend<br/>TypeScript, React]
+    end
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+    subgraph "API Layer"
+        Laravel[Laravel API<br/>PHP 8.3, DDD]
+        Sanctum[Laravel Sanctum<br/>Authentication]
+    end
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+    subgraph "Infrastructure"
+        Caddy[Caddy<br/>HTTP/2, HTTP/3]
+        Redis[(Redis<br/>Cache, Session, Queue)]
+        Postgres[(PostgreSQL 16<br/>Primary Database)]
+    end
 
-## Learning Laravel
+    Next -->|REST API| Caddy
+    Caddy --> Laravel
+    Laravel --> Sanctum
+    Laravel --> Postgres
+    Laravel --> Redis
+```
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## System Requirements
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+-   Docker Desktop 4.0+
+-   Just (command runner)
+-   Git
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+## Quick Start
 
-## Laravel Sponsors
+```bash
+# Clone repository
+git clone <repository-url>
+cd junction-bank
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+# Initial setup
+just setup
 
-### Premium Partners
+# Access application
+open http://localhost:8000
+```
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+## Project Structure
+
+```
+junction-bank/
+├── app/                          # Laravel application
+│   ├── Domains/                  # Domain-driven design modules
+│   │   └── Categories/
+│   │       ├── Actions/          # Business logic
+│   │       ├── DTOs/             # Data transfer objects
+│   │       ├── Models/           # Eloquent models
+│   │       └── Repositories/     # Data access layer
+│   ├── Http/
+│   │   ├── Controllers/          # HTTP controllers (thin)
+│   │   └── Middleware/           # HTTP middleware
+│   └── Policies/                 # Authorization policies
+├── next-js-app/                  # Next.js frontend
+│   ├── app/                      # App router pages
+│   ├── components/               # React components
+│   ├── domains/                  # Frontend domain logic
+│   └── infrastructure/           # API clients, utils
+├── docker/                       # Docker configuration
+│   ├── php/                      # PHP-FPM images
+│   ├── caddy/                    # Caddy config
+│   ├── postgres/                 # PostgreSQL config
+│   └── redis/                    # Redis config
+├── .development-context/         # Development docs
+│   ├── ADRs/                     # Architecture decisions
+│   ├── PRDs/                     # Product requirements
+│   └── rules/                    # Development rules
+└── tests/                        # Test suite
+```
+
+## Development
+
+### Essential Commands
+
+```bash
+# Environment management
+just dev              # Start development environment
+just dev-stop         # Stop development environment
+just dev-logs         # View logs
+
+# Application
+just artisan [cmd]    # Run artisan command
+just composer [cmd]   # Run composer command
+just ssh              # SSH into PHP container
+
+# Database
+just migrate          # Run migrations
+just migrate-fresh    # Fresh migration + seed
+just seed             # Run seeders
+just db-backup        # Backup database
+just db-restore       # Restore latest backup
+just psql             # PostgreSQL CLI
+
+# Code quality
+just phpstan          # Static analysis
+just pint             # Code style check/fix
+just test             # Run tests
+just quality          # All quality checks
+
+# Build
+just build-dev        # Build dev images
+just build-prod       # Build prod images
+```
+
+Full command reference: `just --list`
+
+### Development Services
+
+| Service         | URL                   | Purpose              |
+| --------------- | --------------------- | -------------------- |
+| Application     | http://localhost:8000 | Main Laravel API     |
+| Next.js         | http://localhost:3000 | Frontend application |
+| Vite Dev Server | http://localhost:5173 | Hot module reload    |
+| Adminer         | http://localhost:8080 | Database management  |
+| MailHog         | http://localhost:8025 | Email testing        |
+| Redis Commander | http://localhost:8081 | Redis management     |
+
+### Environment Configuration
+
+1. Copy `.env.example` to `.env`
+2. Configure essential variables:
+
+```env
+APP_NAME="Junction Bank"
+APP_ENV=local
+APP_DEBUG=true
+
+DB_CONNECTION=pgsql
+DB_HOST=postgres
+DB_DATABASE=junction_bank
+
+REDIS_HOST=redis
+CACHE_DRIVER=redis
+SESSION_DRIVER=redis
+QUEUE_CONNECTION=redis
+```
+
+### Domain-Driven Design
+
+Junction Bank follows DDD principles. Each domain is self-contained:
+
+```
+app/Domains/{DomainName}/
+├── Actions/              # Business logic (use cases)
+├── DTOs/                 # Data transfer objects
+├── Models/               # Eloquent models
+├── Repositories/         # Data access abstraction
+└── Policies/             # Authorization rules
+```
+
+**Key Principles:**
+
+-   Controllers delegate to Actions
+-   Actions contain business logic
+-   Repositories abstract data access
+-   DTOs transfer data between layers
+-   Models stay in their domain
+
+See: [.development-context/rules/](.development-context/rules/) for complete guidelines.
+
+## Testing
+
+```bash
+# Run all tests
+just test
+
+# Run specific test suites
+just test-pest          # Pest PHP tests
+just test-arch          # Architecture tests
+
+# Code quality
+just phpstan            # Static analysis
+just pint-test          # Style check without fixing
+```
+
+### Test Structure
+
+```bash
+tests/
+├── Feature/            # Integration tests
+├── Unit/               # Unit tests
+└── Architecture/       # Architecture constraints
+```
+
+## API Documentation
+
+API documentation available at `/api/documentation` when running in development mode.
+
+See: [.development-context/api-endpoints-reference.md](.development-context/api-endpoints-reference.md)
+
+## Architecture Decisions
+
+Key architectural decisions documented in [.development-context/ADRs/](.development-context/ADRs/):
+
+-   [Docker + Laravel Infrastructure](/.development-context/ADRs/001-docker-laravel-infrastructure.md)
+-   [Transaction Type System](/.development-context/ADRs/94-transaction-type-system.md)
+-   [Controller Control Flow](/.development-context/ADRs/control%20flow%20through%20controllers.md)
+-   [Resource Drawer Pattern](/.development-context/ADRs/resource-drawer-usage.md)
+
+## Troubleshooting
+
+### Common Issues
+
+**Container won't start:**
+
+```bash
+just dev-logs           # Check logs
+just health             # Service status
+just clean && just setup # Nuclear option
+```
+
+**Permission errors:**
+
+```bash
+echo "USER_ID=$(id -u)" >> .env
+echo "GROUP_ID=$(id -g)" >> .env
+just build-dev
+```
+
+**Database connection:**
+
+```bash
+just psql               # Test connection
+just migrate-fresh      # Reset database
+```
+
+**Cache issues:**
+
+```bash
+just artisan cache:clear
+just artisan config:clear
+just artisan route:clear
+just artisan view:clear
+```
+
+Complete troubleshooting: [docker/README.md](docker/README.md)
+
+## Production Deployment
+
+```bash
+# Build production images
+just build-prod
+
+# Deploy
+just prod
+
+# Run migrations
+docker compose -f compose.yml -f compose.prod.yml exec php php artisan migrate --force
+```
+
+Production configuration includes:
+
+-   Read-only filesystem
+-   OPcache with JIT
+-   Resource limits
+-   Security hardening
+-   Automated backups
+
+See: [docker/README.md](docker/README.md) for complete deployment guide.
 
 ## Contributing
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow and guidelines.
 
-## Code of Conduct
+## Security
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+-   Laravel Sanctum for API authentication
+-   Security headers middleware
+-   CORS configuration
+-   Rate limiting
+-   SQL injection protection (PDO)
+-   XSS protection (Blade escaping)
 
-## Security Vulnerabilities
+Security issues: Create a private security advisory.
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+## Performance
+
+-   PostgreSQL 16 with query optimization
+-   Redis for caching, sessions, queues
+-   OPcache with JIT (production)
+-   HTTP/2 and HTTP/3 support
+-   Asset compilation and minification
 
 ## License
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+Proprietary. All rights reserved.
+
+## Support
+
+1. Check [docker/README.md](docker/README.md)
+2. Review [.development-context/](.development-context/)
+3. Run `just health` for diagnostics
+4. Check `storage/logs/` for application logs

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # Development environment overrides
 # Usage: docker compose -f compose.yml -f compose.dev.yml up
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # Production environment overrides
 # Usage: docker compose -f compose.yml -f compose.prod.yml up -d
 

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # Test environment overrides
 # Usage: docker compose -f compose.yml -f compose.test.yml up --abort-on-container-exit
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # Base configuration shared across all environments
 # Override with compose.dev.yml, compose.prod.yml, or compose.test.yml
 

--- a/config/database.php
+++ b/config/database.php
@@ -16,7 +16,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'sqlite'),
+    'default' => env('DB_CONNECTION', 'pgsql'),
 
     /*
     |--------------------------------------------------------------------------
@@ -148,7 +148,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-database-'),
+            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')) . '-database-'),
             'persistent' => env('REDIS_PERSISTENT', false),
         ],
 

--- a/database/migrations/2025_10_14_005704_create_categories_table.php
+++ b/database/migrations/2025_10_14_005704_create_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->enum('type', ['income', 'expense']);
+            $table->text('notes')->nullable();
+            $table->boolean('is_recurring')->default(false);
+            $table->timestamps();
+
+            $table->index('type');
+            $table->index('is_recurring');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,473 @@
+# API Documentation
+
+## Overview
+
+Junction Bank API is a RESTful API built with Laravel, following domain-driven design principles. Authentication uses Laravel Sanctum with Bearer tokens.
+
+## Base URLs
+
+-   Development: `http://localhost:8000/api`
+-   Production: `https://api.junctionbank.com/api`
+
+## Authentication
+
+### Bearer Token Authentication
+
+All authenticated endpoints require a Bearer token in the Authorization header:
+
+```http
+Authorization: Bearer {token}
+```
+
+### Obtaining a Token
+
+**Register:**
+
+```bash
+curl -X POST http://localhost:8000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "password": "SecurePassword123!",
+    "password_confirmation": "SecurePassword123!"
+  }'
+```
+
+**Response:**
+
+```json
+{
+    "data": {
+        "user": {
+            "id": 1,
+            "name": "John Doe",
+            "email": "john@example.com",
+            "created_at": "2024-01-15T00:00:00Z"
+        },
+        "token": "1|abc123def456..."
+    }
+}
+```
+
+**Login:**
+
+```bash
+curl -X POST http://localhost:8000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "john@example.com",
+    "password": "SecurePassword123!"
+  }'
+```
+
+## Common Patterns
+
+### Pagination
+
+List endpoints support pagination via query parameters:
+
+```bash
+GET /api/transactions?page=2&limit=25
+```
+
+**Response:**
+
+```json
+{
+  "data": [...],
+  "pagination": {
+    "currentPage": 2,
+    "totalPages": 10,
+    "totalItems": 250,
+    "perPage": 25,
+    "hasNext": true,
+    "hasPrev": true
+  }
+}
+```
+
+### Error Responses
+
+All errors follow a consistent format:
+
+```json
+{
+    "error": {
+        "message": "The given data was invalid.",
+        "code": "VALIDATION_ERROR",
+        "details": {
+            "email": ["The email field is required."],
+            "password": ["The password must be at least 8 characters."]
+        }
+    }
+}
+```
+
+**HTTP Status Codes:**
+
+-   `200` - Success
+-   `201` - Created
+-   `400` - Bad Request
+-   `401` - Unauthorized
+-   `403` - Forbidden
+-   `404` - Not Found
+-   `409` - Conflict
+-   `422` - Unprocessable Entity
+-   `500` - Internal Server Error
+
+### Rate Limiting
+
+Rate limits are applied per minute:
+
+-   **Authenticated endpoints:** 120 requests/minute
+-   **Import endpoints:** 10 requests/minute
+-   **Auth endpoints:** 10 requests/minute
+
+**Headers:**
+
+```http
+X-RateLimit-Limit: 120
+X-RateLimit-Remaining: 119
+X-RateLimit-Reset: 1234567890
+```
+
+## Domain Examples
+
+### Categories
+
+**Create Category:**
+
+```bash
+curl -X POST http://localhost:8000/api/categories \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Groceries",
+    "type": "expense",
+    "notes": "Food and household items"
+  }'
+```
+
+**List Categories:**
+
+```bash
+curl -X GET http://localhost:8000/api/categories \
+  -H "Authorization: Bearer {token}"
+```
+
+**Delete Category:**
+
+```bash
+curl -X DELETE http://localhost:8000/api/categories/1 \
+  -H "Authorization: Bearer {token}"
+```
+
+### Transactions
+
+**Create Transaction:**
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Grocery Store",
+    "amountCAD": 125.50,
+    "categoryId": 1,
+    "date": "2024-01-15",
+    "monthId": 1,
+    "type": "Expense",
+    "notes": "Weekly shopping"
+  }'
+```
+
+**List Transactions (filtered by month):**
+
+```bash
+curl -X GET "http://localhost:8000/api/transactions?monthId=1" \
+  -H "Authorization: Bearer {token}"
+```
+
+**Update Transaction:**
+
+```bash
+curl -X PUT http://localhost:8000/api/transactions/1 \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Updated Grocery Store",
+    "amountCAD": 130.00
+  }'
+```
+
+### CSV Import
+
+**Preview Import:**
+
+```bash
+curl -X POST http://localhost:8000/api/transactions/preview \
+  -H "Authorization: Bearer {token}" \
+  -F "file=@transactions.csv"
+```
+
+**CSV Format:**
+
+```csv
+Date,Name,AMOUNT CAD,AMOUNT USD,Category Id,Notes,Type
+01/15/2024,Grocery Store,125.50,,1,Weekly shopping,Expense
+01/16/2024,Salary,5000.00,,2,Monthly income,Income
+```
+
+**Supported Date Formats:**
+
+-   MM/DD/YYYY (US)
+-   DD/MM/YYYY (European)
+-   YYYY-MM-DD (ISO)
+-   DD.MM.YYYY
+
+**Process Import:**
+
+```bash
+curl -X POST http://localhost:8000/api/transactions/import \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transactions": [
+      {
+        "name": "Grocery Store",
+        "amountCAD": 125.50,
+        "categoryId": 1,
+        "date": "2024-01-15",
+        "monthId": 1,
+        "type": "Expense"
+      }
+    ]
+  }'
+```
+
+### Months
+
+**Create Month:**
+
+```bash
+curl -X POST http://localhost:8000/api/months \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "month": 1,
+    "year": 2024,
+    "notes": "January budget"
+  }'
+```
+
+**Get Latest Month:**
+
+```bash
+curl -X GET http://localhost:8000/api/months/latest \
+  -H "Authorization: Bearer {token}"
+```
+
+**Get Category Spending:**
+
+```bash
+curl -X GET http://localhost:8000/api/months/1/spending \
+  -H "Authorization: Bearer {token}"
+```
+
+**Recalculate Recurring Expenses:**
+
+```bash
+# For specific month
+curl -X POST http://localhost:8000/api/months/recalculate \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"monthId": 1}'
+
+# For all months
+curl -X POST http://localhost:8000/api/months/recalculate \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### Recurring Transactions
+
+**Create Recurring Transaction:**
+
+```bash
+curl -X POST http://localhost:8000/api/recurring-transactions \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Netflix Subscription",
+    "amountCAD": 15.99,
+    "categoryId": 5,
+    "dayOfMonth": 15,
+    "type": "Expense",
+    "notes": "Monthly streaming"
+  }'
+```
+
+**List Recurring Transactions:**
+
+```bash
+curl -X GET http://localhost:8000/api/recurring-transactions \
+  -H "Authorization: Bearer {token}"
+```
+
+## OpenAPI Specification
+
+The complete API specification is available in OpenAPI 3.0 format:
+
+**File:** `docs/openapi.yaml`
+
+### Using the OpenAPI Spec
+
+**Swagger UI:**
+
+```bash
+# Install Swagger UI
+npm install -g swagger-ui-express
+
+# Serve the spec
+swagger-ui-express docs/openapi.yaml
+```
+
+**Postman:**
+
+1. Import `docs/openapi.yaml` into Postman
+2. Collections and environments will be auto-generated
+
+**Code Generation:**
+
+```bash
+# Generate TypeScript client
+npx @openapitools/openapi-generator-cli generate \
+  -i docs/openapi.yaml \
+  -g typescript-fetch \
+  -o generated/api-client
+```
+
+## Development Tools
+
+### Testing with curl
+
+Export token for convenience:
+
+```bash
+export TOKEN="1|abc123def456..."
+
+curl -X GET http://localhost:8000/api/categories \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Using HTTPie
+
+```bash
+# Login
+http POST localhost:8000/api/auth/login \
+  email=john@example.com \
+  password=SecurePassword123!
+
+# Set token
+TOKEN="1|abc123def456..."
+
+# Make requests
+http GET localhost:8000/api/categories \
+  "Authorization: Bearer $TOKEN"
+```
+
+### Postman Collection
+
+Import `docs/openapi.yaml` into Postman for a complete collection.
+
+**Environment Variables:**
+
+-   `base_url`: `http://localhost:8000/api`
+-   `token`: Your Bearer token
+
+## Business Logic
+
+### Category Rules
+
+-   Category names must be unique
+-   Cannot delete categories with associated transactions
+-   Types: `income` or `expense`
+
+### Transaction Rules
+
+-   Requires valid `categoryId` and `monthId`
+-   Date must match the month's year/month
+-   Amount must be positive
+-   Either `amountCAD` or `amountUSD` required (both allowed)
+
+### Month Rules
+
+-   Month/year combination must be unique
+-   Cannot delete months with transactions
+-   Creating a month automatically applies recurring transactions
+-   Totals auto-calculate based on transactions
+
+### Recurring Transaction Rules
+
+-   Applies to all future months when created
+-   Does not retroactively update past transactions
+-   Deleting does not remove already-created transactions
+-   `dayOfMonth` defaults to 1 if not specified
+
+## Performance
+
+### Caching
+
+The following endpoints use Redis caching:
+
+-   `GET /api/categories` - 1 hour
+-   `GET /api/transactions` - 5 minutes
+-   `GET /api/months` - 10 minutes
+
+Cache is automatically invalidated on mutations.
+
+### Batch Operations
+
+Use the CSV import endpoints for bulk transaction creation:
+
+```
+POST /api/transactions/preview  # Validate
+POST /api/transactions/import   # Process
+```
+
+Batch import uses database transactions and optimized inserts.
+
+## CORS Configuration
+
+**Development:**
+
+-   Allowed Origin: `http://localhost:3000`
+-   Credentials: true
+
+**Production:**
+
+-   Allowed Origin: `https://app.junctionbank.com`
+-   Credentials: true
+
+**Methods:** GET, POST, PUT, DELETE, OPTIONS  
+**Headers:** Content-Type, Authorization, X-Requested-With
+
+## Webhooks (Future)
+
+Webhook support planned for:
+
+-   Transaction created/updated/deleted
+-   Month created/updated
+-   Recurring transaction applied
+
+## GraphQL (Future)
+
+GraphQL endpoint planned for more flexible queries.
+
+## Support
+
+-   **Documentation:** [README.md](../README.md)
+-   **OpenAPI Spec:** [openapi.yaml](openapi.yaml)
+-   **Endpoint Reference:** [.development-context/api-endpoints-reference.md](../.development-context/api-endpoints-reference.md)

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -1,0 +1,858 @@
+# Development Best Practices
+
+## Code Organization
+
+### Domain-Driven Design Structure
+
+**Organize by domain, not by layer:**
+
+```
+✓ Good
+app/Domains/Categories/
+├── Actions/
+├── DTOs/
+├── Models/
+└── Repositories/
+
+✗ Bad
+app/
+├── Actions/
+│   ├── CategoryAction.php
+│   ├── TransactionAction.php
+├── Models/
+│   ├── Category.php
+│   ├── Transaction.php
+```
+
+**Keep domains isolated:**
+
+```php
+// ✓ Good - Use DTOs for cross-domain communication
+class CreateTransactionAction
+{
+    public function execute(TransactionData $data, int $categoryId): Transaction
+    {
+        $category = $this->categoryRepository->find($categoryId);
+        // Use category data, not the model directly
+    }
+}
+
+// ✗ Bad - Direct model dependency across domains
+use App\Domains\Categories\Models\Category;
+class CreateTransactionAction
+{
+    public function execute(TransactionData $data, Category $category): Transaction
+```
+
+### File Size Guidelines
+
+**Keep files focused and small:**
+
+-   Controllers: < 100 lines
+-   Actions: < 150 lines
+-   Models: < 200 lines
+-   DTOs: < 100 lines
+
+**When to split:**
+
+-   Single file > 300 lines → Extract concerns
+-   Class > 10 methods → Split responsibilities
+-   Method > 50 lines → Extract helper methods
+
+### Naming Conventions
+
+**Actions:**
+
+```php
+// ✓ Good - Verb + Noun
+CreateCategoryAction
+UpdateTransactionAction
+DeleteRecurringTransactionAction
+
+// ✗ Bad
+CategoryAction
+DoTransaction
+Handler
+```
+
+**DTOs:**
+
+```php
+// ✓ Good - Noun + Data suffix
+CategoryData
+TransactionFilterData
+ImportPreviewData
+
+// ✗ Bad
+Category
+TransactionDTO
+TData
+```
+
+**Repositories:**
+
+```php
+// ✓ Good - Interface + Implementation
+CategoryRepository (interface)
+EloquentCategoryRepository (implementation)
+
+// ✗ Bad
+CategoryRepo
+Categories
+CategoryDatabase
+```
+
+## Code Quality
+
+### Type Safety
+
+**Always use strict types:**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Categories\Actions;
+
+// ✓ Good - All types declared
+final class CreateCategoryAction
+{
+    public function __construct(
+        private readonly CategoryRepository $repository
+    ) {}
+
+    public function execute(CategoryData $data): Category
+    {
+        return $this->repository->create($data);
+    }
+}
+
+// ✗ Bad - Missing types
+class CreateCategoryAction
+{
+    public function __construct($repository) {}
+
+    public function execute($data)
+    {
+        return $this->repository->create($data);
+    }
+}
+```
+
+**Use readonly properties:**
+
+```php
+// ✓ Good - Immutable DTOs
+final readonly class CategoryData
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public ?string $notes = null
+    ) {}
+}
+
+// ✗ Bad - Mutable
+class CategoryData
+{
+    public string $name;
+    public string $type;
+}
+```
+
+### Error Handling
+
+**Use specific exceptions:**
+
+```php
+// ✓ Good - Domain-specific exceptions
+class CategoryNotFoundException extends DomainException
+{
+    public static function forId(int $id): self
+    {
+        return new self("Category with ID {$id} not found");
+    }
+}
+
+// Usage
+if (!$category) {
+    throw CategoryNotFoundException::forId($id);
+}
+
+// ✗ Bad - Generic exceptions
+if (!$category) {
+    throw new Exception("Not found");
+}
+```
+
+**Handle errors at appropriate layer:**
+
+```php
+// ✓ Good - Controller handles HTTP concerns
+public function store(CreateCategoryRequest $request): JsonResponse
+{
+    try {
+        $category = $this->action->execute(
+            CategoryData::fromRequest($request)
+        );
+        return response()->json($category, 201);
+    } catch (DomainException $e) {
+        return response()->json(['error' => $e->getMessage()], 400);
+    }
+}
+
+// ✗ Bad - Action handles HTTP concerns
+public function execute(CategoryData $data): JsonResponse
+{
+    try {
+        $category = $this->repository->create($data);
+        return response()->json($category, 201);
+    } catch (Exception $e) {
+        return response()->json(['error' => 'Failed'], 500);
+    }
+}
+```
+
+### Validation
+
+**Use Form Requests:**
+
+```php
+// ✓ Good - Dedicated validation
+class CreateCategoryRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'unique:categories'],
+            'type' => ['required', 'in:income,expense'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}
+
+// ✗ Bad - Validation in controller
+public function store(Request $request): JsonResponse
+{
+    $request->validate([
+        'name' => 'required|string|max:255|unique:categories',
+        // ...
+    ]);
+}
+```
+
+## Database Best Practices
+
+### Migrations
+
+**Keep migrations atomic:**
+
+```php
+// ✓ Good - Single concern
+public function up(): void
+{
+    Schema::create('categories', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+        $table->enum('type', ['income', 'expense']);
+        $table->timestamps();
+    });
+}
+
+// ✗ Bad - Multiple unrelated changes
+public function up(): void
+{
+    Schema::create('categories', function (Blueprint $table) { ... });
+    Schema::create('transactions', function (Blueprint $table) { ... });
+    DB::table('settings')->insert(['key' => 'foo']);
+}
+```
+
+**Always provide rollback:**
+
+```php
+// ✓ Good - Reversible
+public function down(): void
+{
+    Schema::dropIfExists('categories');
+}
+
+// ✗ Bad - No rollback
+public function down(): void
+{
+    //
+}
+```
+
+### Query Optimization
+
+**Eager load relationships:**
+
+```php
+// ✓ Good - Avoids N+1
+$transactions = Transaction::with('category')->get();
+
+// ✗ Bad - N+1 query problem
+$transactions = Transaction::all();
+foreach ($transactions as $transaction) {
+    echo $transaction->category->name; // N queries
+}
+```
+
+**Use specific selects:**
+
+```php
+// ✓ Good - Only needed columns
+Category::select(['id', 'name', 'type'])->get();
+
+// ✗ Bad - Fetching unnecessary data
+Category::all(); // SELECT *
+```
+
+**Index foreign keys:**
+
+```php
+// ✓ Good - Indexed for performance
+$table->foreignId('category_id')
+    ->constrained()
+    ->onDelete('cascade');
+
+// Composite index for common queries
+$table->index(['user_id', 'created_at']);
+```
+
+## Testing Best Practices
+
+### Test Organization
+
+**Organize tests by domain:**
+
+```
+tests/
+├── Unit/
+│   └── Domains/
+│       ├── Categories/
+│       │   ├── Actions/
+│       │   │   └── CreateCategoryActionTest.php
+│       │   └── DTOs/
+│       └── Transactions/
+└── Feature/
+    └── Http/
+        └── Controllers/
+            └── CategoryControllerTest.php
+```
+
+### Test Naming
+
+**Use descriptive test names:**
+
+```php
+// ✓ Good - Clear intent
+it('creates a category with valid data', function () { ... });
+it('throws exception when category name is duplicate', function () { ... });
+it('returns 404 when category not found', function () { ... });
+
+// ✗ Bad - Unclear
+it('test create', function () { ... });
+it('works', function () { ... });
+```
+
+### Test Structure
+
+**Follow Arrange-Act-Assert:**
+
+```php
+it('creates a category with valid data', function () {
+    // Arrange
+    $data = CategoryData::from([
+        'name' => 'Groceries',
+        'type' => 'expense',
+    ]);
+    $action = new CreateCategoryAction(new EloquentCategoryRepository());
+
+    // Act
+    $category = $action->execute($data);
+
+    // Assert
+    expect($category)->toBeInstanceOf(Category::class);
+    expect($category->name)->toBe('Groceries');
+    expect($category->type)->toBe('expense');
+});
+```
+
+### Test Coverage
+
+**Focus on critical paths:**
+
+```php
+// ✓ Must test
+- Business logic in Actions
+- Domain rules and validation
+- Repository implementations
+- Critical user flows
+
+// ✓ Should test
+- Controllers (integration)
+- Form requests
+- DTOs
+- Policies
+
+// ✓ Can skip
+- Simple getters/setters
+- Framework code
+- Third-party packages
+```
+
+## Performance Guidelines
+
+### Caching Strategy
+
+**Cache expensive operations:**
+
+```php
+// ✓ Good - Cache database queries
+public function findAll(): Collection
+{
+    return Cache::remember(
+        'categories.all',
+        now()->addHour(),
+        fn () => Category::all()
+    );
+}
+
+// Invalidate on changes
+public function create(CategoryData $data): Category
+{
+    $category = Category::create([...]);
+    Cache::forget('categories.all');
+    return $category;
+}
+```
+
+**Use cache tags for granular invalidation:**
+
+```php
+// ✓ Good - Tagged caches
+Cache::tags(['categories', "user:{$userId}"])
+    ->remember($key, $ttl, $callback);
+
+// Invalidate specific tags
+Cache::tags(['categories'])->flush();
+```
+
+### Queue Background Jobs
+
+**Queue expensive operations:**
+
+```php
+// ✓ Good - Asynchronous
+public function import(array $transactions): void
+{
+    ProcessTransactionImportJob::dispatch($transactions);
+}
+
+// ✗ Bad - Synchronous
+public function import(array $transactions): void
+{
+    foreach ($transactions as $transaction) {
+        $this->createTransaction($transaction); // Slow
+    }
+}
+```
+
+### Batch Operations
+
+**Use batch inserts:**
+
+```php
+// ✓ Good - Single query
+DB::table('transactions')->insert($data);
+
+// ✗ Bad - Multiple queries
+foreach ($data as $row) {
+    DB::table('transactions')->insert($row);
+}
+```
+
+## Security Best Practices
+
+### Input Validation
+
+**Always validate and sanitize:**
+
+```php
+// ✓ Good - Validated via Form Request
+public function store(CreateCategoryRequest $request): JsonResponse
+{
+    $data = CategoryData::fromRequest($request); // Already validated
+}
+
+// ✗ Bad - Direct from request
+public function store(Request $request): JsonResponse
+{
+    Category::create($request->all()); // Dangerous!
+}
+```
+
+### Authorization
+
+**Use Policies consistently:**
+
+```php
+// ✓ Good - Policy check
+public function update(Category $category, UpdateCategoryRequest $request): JsonResponse
+{
+    $this->authorize('update', $category);
+    // ...
+}
+
+// ✗ Bad - Manual checks
+public function update(Category $category, UpdateCategoryRequest $request): JsonResponse
+{
+    if ($category->user_id !== auth()->id()) {
+        abort(403);
+    }
+}
+```
+
+### SQL Injection Prevention
+
+**Use parameter binding:**
+
+```php
+// ✓ Good - Parameterized query
+DB::table('categories')
+    ->where('name', $name)
+    ->get();
+
+// ✗ Bad - String concatenation
+DB::select("SELECT * FROM categories WHERE name = '{$name}'");
+```
+
+### XSS Prevention
+
+**Escape output (Blade does this automatically):**
+
+```php
+// ✓ Good - Escaped
+{{ $category->name }}
+
+// ✗ Bad - Unescaped
+{!! $category->name !!}
+```
+
+## Git Workflow
+
+### Commit Messages
+
+**Write clear commit messages:**
+
+```bash
+# ✓ Good
+feat(categories): add bulk category import
+fix(transactions): resolve date parsing error
+refactor(auth): extract token validation logic
+test(categories): add repository unit tests
+
+# ✗ Bad
+update
+fix bug
+wip
+changes
+```
+
+### Branch Management
+
+**Use descriptive branch names:**
+
+```bash
+# ✓ Good
+feature/TICKET-123-add-bulk-import
+bugfix/TICKET-456-fix-date-parsing
+refactor/TICKET-789-extract-validation
+
+# ✗ Bad
+new-feature
+fix
+updates
+my-branch
+```
+
+### Pull Requests
+
+**Before creating PR:**
+
+```bash
+# Run quality checks
+just quality
+
+# Run tests
+just test
+
+# Check for uncommitted changes
+git status
+
+# Rebase on main
+git fetch origin main
+git rebase origin/main
+```
+
+## Code Review Guidelines
+
+### As Reviewer
+
+**Focus on:**
+
+-   Architecture and design
+-   Business logic correctness
+-   Security concerns
+-   Performance implications
+-   Test coverage
+-   Code readability
+
+**Don't focus on:**
+
+-   Personal style preferences (use Pint)
+-   Subjective opinions
+-   Premature optimization
+
+**Review checklist:**
+
+```markdown
+-   [ ] Follows DDD principles
+-   [ ] Controllers are thin
+-   [ ] Business logic in Actions
+-   [ ] Repository pattern used correctly
+-   [ ] DTOs for data transfer
+-   [ ] Tests cover changes
+-   [ ] No obvious security issues
+-   [ ] Error handling appropriate
+-   [ ] Documentation updated
+```
+
+## Documentation Standards
+
+### Code Comments
+
+**Comment why, not what:**
+
+```php
+// ✓ Good - Explains reasoning
+// We use soft deletes because transactions reference categories
+// and we need to maintain historical data integrity
+$table->softDeletes();
+
+// ✗ Bad - Obvious
+// Add soft deletes column
+$table->softDeletes();
+```
+
+**PHPDoc for public APIs:**
+
+```php
+// ✓ Good - Documented public interface
+/**
+ * Create a new category.
+ *
+ * @param CategoryData $data The category data
+ * @return Category The created category
+ * @throws DomainException When name is duplicate
+ */
+public function execute(CategoryData $data): Category
+
+// ✗ Bad - No documentation
+public function execute(CategoryData $data): Category
+```
+
+### README Updates
+
+**Keep documentation current:**
+
+-   Update when adding features
+-   Document breaking changes
+-   Include migration steps
+-   Add examples for new APIs
+
+## Performance Monitoring
+
+### Identify Slow Queries
+
+**Use Laravel Debugbar in development:**
+
+```php
+// Identifies N+1 queries
+// Shows query execution time
+// Highlights duplicate queries
+```
+
+**Log slow queries in production:**
+
+```php
+// config/database.php
+'connections' => [
+    'pgsql' => [
+        // Log queries > 1000ms
+        'options' => [
+            PDO::ATTR_TIMEOUT => 1000,
+        ],
+    ],
+],
+```
+
+### Monitor Key Metrics
+
+**Track in production:**
+
+-   Response time (p50, p95, p99)
+-   Error rate
+-   Database query time
+-   Cache hit ratio
+-   Queue processing time
+-   Memory usage
+
+## Deployment Best Practices
+
+### Environment Configuration
+
+**Never commit secrets:**
+
+```bash
+# ✓ Good - Use environment variables
+DB_PASSWORD=secret
+
+# ✗ Bad - Hardcoded
+$password = 'secret123';
+```
+
+**Use different configs per environment:**
+
+```php
+// ✓ Good - Environment-aware
+'debug' => env('APP_DEBUG', false),
+'cache_ttl' => env('CACHE_TTL', 3600),
+
+// ✗ Bad - Hardcoded
+'debug' => true,
+'cache_ttl' => 60,
+```
+
+### Pre-Deployment Checklist
+
+```bash
+# Code quality
+just quality
+
+# Tests
+just test
+
+# Database
+just migrate --pretend  # Dry run
+
+# Build
+just build-prod
+
+# Backup
+just db-backup
+```
+
+## Maintenance
+
+### Regular Tasks
+
+**Weekly:**
+
+-   Review logs for errors
+-   Check performance metrics
+-   Update dependencies (security patches)
+-   Clean up stale branches
+
+**Monthly:**
+
+-   Run `docker system prune`
+-   Review and archive old logs
+-   Database performance tuning
+-   Security audit
+
+**Quarterly:**
+
+-   Major dependency updates
+-   Performance optimization review
+-   Architecture review
+-   Documentation audit
+
+## Resources
+
+### Internal Documentation
+
+-   [README.md](../README.md) - Setup instructions
+-   [CONTRIBUTING.md](../CONTRIBUTING.md) - Development workflow
+-   [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Common issues
+-   [.development-context/rules/](../.development-context/rules/) - Detailed coding rules
+-   [.development-context/ADRs/](../.development-context/ADRs/) - Architecture decisions
+
+### External Resources
+
+-   [Laravel Documentation](https://laravel.com/docs)
+-   [Laravel Best Practices](https://github.com/alexeymezenin/laravel-best-practices)
+-   [Laravel Beyond CRUD](https://laravel-beyond-crud.com/)
+-   [Domain-Driven Design (Eric Evans)](https://www.domainlanguage.com/ddd/)
+-   [Clean Architecture (Robert Martin)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+
+## Quick Reference
+
+### Command Cheat Sheet
+
+```bash
+# Development
+just dev              # Start environment
+just dev-stop         # Stop environment
+just dev-logs         # View logs
+
+# Database
+just migrate          # Run migrations
+just migrate-fresh    # Reset database
+just db-backup        # Backup database
+
+# Code Quality
+just phpstan          # Static analysis
+just pint             # Fix code style
+just test             # Run tests
+just quality          # All checks
+
+# Application
+just artisan [cmd]    # Run artisan command
+just composer [cmd]   # Run composer command
+just ssh              # SSH into container
+```
+
+### Common Patterns
+
+```php
+// Controller → Action → Repository
+Controller::method()
+    → Action::execute(DTO)
+        → Repository::method(DTO)
+            → Model
+
+// Error handling
+try {
+    $result = $action->execute($data);
+} catch (DomainException $e) {
+    // Handle domain errors
+} catch (Exception $e) {
+    // Handle unexpected errors
+}
+
+// Testing
+it('does something', function () {
+    // Arrange
+    $data = ...;
+
+    // Act
+    $result = $action->execute($data);
+
+    // Assert
+    expect($result)->toBe(...);
+});
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,342 @@
+# Documentation
+
+Comprehensive documentation for Junction Bank development, deployment, and maintenance.
+
+## Quick Start
+
+-   **[README.md](../README.md)** - Project overview and quick setup
+-   **[CONTRIBUTING.md](../CONTRIBUTING.md)** - Development workflow and contribution guidelines
+
+## API Documentation
+
+-   **[API.md](API.md)** - Complete API documentation with examples
+-   **[openapi.yaml](openapi.yaml)** - OpenAPI 3.0 specification for automated tools
+
+### Using the API Documentation
+
+**Swagger UI:**
+
+```bash
+npx swagger-ui-serve docs/openapi.yaml
+```
+
+**Import to Postman:**
+
+1. Open Postman
+2. Import → openapi.yaml
+3. Auto-generated collection ready
+
+**Generate Client:**
+
+```bash
+npx @openapitools/openapi-generator-cli generate \
+  -i docs/openapi.yaml \
+  -g typescript-fetch \
+  -o generated/api-client
+```
+
+## Development Guides
+
+### Essential Reading
+
+-   **[BEST_PRACTICES.md](BEST_PRACTICES.md)** - Coding standards, patterns, and workflows
+-   **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues and solutions
+
+### Deep Dives
+
+-   **[docker/README.md](../docker/README.md)** - Docker architecture and configuration
+-   **[.development-context/rules/](../.development-context/rules/)** - Detailed coding rules
+-   **[.development-context/ADRs/](../.development-context/ADRs/)** - Architecture decisions
+
+## Architecture Documentation
+
+### Architecture Decision Records (ADRs)
+
+Key decisions documented in `.development-context/ADRs/`:
+
+-   **[ADR-001: Docker Infrastructure](../.development-context/ADRs/001-docker-laravel-infrastructure.md)**
+
+    -   Multi-environment Docker setup
+    -   Service architecture
+    -   Development/production optimization
+
+-   **[ADR-002: Domain-Driven Design](../.development-context/ADRs/002-domain-driven-design-approach.md)**
+
+    -   DDD principles and structure
+    -   Layer responsibilities
+    -   Implementation guidelines
+
+-   **[ADR-003: Laravel Sanctum Authentication](../.development-context/ADRs/003-laravel-sanctum-authentication.md)**
+
+    -   Authentication strategy
+    -   Token management
+    -   Security considerations
+
+-   **[ADR-094: Transaction Type System](../.development-context/ADRs/94-transaction-type-system.md)**
+    -   Type design decisions
+    -   Business rule implications
+
+### Domain Documentation
+
+Detailed domain logic in `.development-context/`:
+
+-   **api-endpoints-reference.md** - Complete endpoint reference
+-   **backend-analysis-report.md** - Backend architecture analysis
+-   **frontend-analysis-report.md** - Frontend architecture analysis
+-   **migration-checklist.md** - Next.js → Laravel migration guide
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+# Development
+just dev              # Start environment
+just dev-stop         # Stop environment
+just dev-logs         # View logs
+
+# Database
+just migrate          # Run migrations
+just migrate-fresh    # Reset database
+just seed             # Run seeders
+just db-backup        # Backup database
+
+# Code Quality
+just phpstan          # Static analysis
+just pint             # Fix code style
+just test             # Run tests
+just quality          # All checks
+
+# Application
+just artisan [cmd]    # Artisan commands
+just composer [cmd]   # Composer commands
+just ssh              # SSH into PHP container
+```
+
+Full command reference: `just --list`
+
+### Development URLs
+
+| Service         | URL                   | Purpose       |
+| --------------- | --------------------- | ------------- |
+| Application     | http://localhost:8000 | Laravel API   |
+| Next.js         | http://localhost:3000 | Frontend      |
+| Adminer         | http://localhost:8080 | Database UI   |
+| MailHog         | http://localhost:8025 | Email testing |
+| Redis Commander | http://localhost:8081 | Redis UI      |
+| Vite            | http://localhost:5173 | Hot reload    |
+
+### Directory Structure
+
+```
+junction-bank/
+├── docs/                         # This directory
+│   ├── API.md                    # API guide
+│   ├── openapi.yaml              # OpenAPI spec
+│   ├── BEST_PRACTICES.md         # Coding standards
+│   └── TROUBLESHOOTING.md        # Problem solving
+├── .development-context/         # Architecture docs
+│   ├── ADRs/                     # Decision records
+│   ├── PRDs/                     # Product requirements
+│   └── rules/                    # Coding rules
+├── app/                          # Laravel application
+│   └── Domains/                  # DDD domains
+├── docker/                       # Docker configuration
+├── next-js-app/                  # Frontend application
+└── tests/                        # Test suite
+```
+
+## For New Developers
+
+### First Day Checklist
+
+1. **Setup Development Environment**
+
+    ```bash
+    git clone <repository>
+    cd junction-bank
+    just setup
+    ```
+
+2. **Read Core Documentation**
+
+    - [README.md](../README.md)
+    - [CONTRIBUTING.md](../CONTRIBUTING.md)
+    - [BEST_PRACTICES.md](BEST_PRACTICES.md)
+
+3. **Understand Architecture**
+
+    - [ADR-002: Domain-Driven Design](../.development-context/ADRs/002-domain-driven-design-approach.md)
+    - [Development Rules](../.development-context/rules/)
+
+4. **Explore Codebase**
+
+    - Review one domain: `app/Domains/Categories/`
+    - Understand layer separation
+    - Read tests: `tests/Unit/Domains/Categories/`
+
+5. **Make First Change**
+    - Create branch: `git checkout -b feature/my-first-change`
+    - Make small change
+    - Run quality checks: `just quality`
+    - Run tests: `just test`
+    - Create pull request
+
+### Learning Path
+
+**Week 1: Environment & Basics**
+
+-   Setup development environment
+-   Understand Docker architecture
+-   Learn Laravel basics
+-   Explore existing domains
+
+**Week 2: Domain-Driven Design**
+
+-   Study DDD principles
+-   Understand layer responsibilities
+-   Review repository pattern
+-   Practice with small features
+
+**Week 3: Testing & Quality**
+
+-   Write unit tests
+-   Write feature tests
+-   Use PHPStan
+-   Follow code style
+
+**Week 4: Full Features**
+
+-   Implement complete features
+-   Follow contribution workflow
+-   Participate in code reviews
+-   Document changes
+
+## For Experienced Developers
+
+### Key Differences
+
+If coming from:
+
+**Traditional Laravel MVC:**
+
+-   Controllers delegate to Actions (not direct model calls)
+-   Repository pattern abstracts data access
+-   DTOs transfer data between layers
+-   Strict domain boundaries
+
+**Next.js/Node:**
+
+-   PHP 8.3 with strict types
+-   Eloquent ORM (not Prisma)
+-   Laravel conventions
+-   Synchronous by default (queue for async)
+
+**Other DDD Implementations:**
+
+-   Laravel-flavored DDD (pragmatic, not pure)
+-   Use Eloquent models (not pure entities)
+-   Repository interfaces with Eloquent implementations
+
+### Advanced Topics
+
+-   **Performance Optimization:** Cache strategies, query optimization
+-   **Security:** Sanctum authentication, authorization policies
+-   **Testing:** Unit, feature, and architecture tests
+-   **Deployment:** Production Docker configuration
+
+## Support & Resources
+
+### Getting Help
+
+1. **Check Documentation**
+
+    - This directory (`docs/`)
+    - `.development-context/` directory
+    - Inline code comments
+
+2. **Search Issues**
+
+    - Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+    - Review closed issues
+    - Search error messages
+
+3. **Run Diagnostics**
+
+    ```bash
+    just health
+    just dev-logs
+    just phpstan
+    ```
+
+4. **Ask Team**
+    - Development team
+    - Code review feedback
+    - Pair programming sessions
+
+### External Resources
+
+-   [Laravel Documentation](https://laravel.com/docs)
+-   [Laravel Best Practices](https://github.com/alexeymezenin/laravel-best-practices)
+-   [Domain-Driven Design](https://www.domainlanguage.com/ddd/)
+-   [Laravel Beyond CRUD](https://laravel-beyond-crud.com/)
+
+## Contributing to Documentation
+
+### When to Update
+
+-   Adding new features
+-   Changing architecture
+-   Fixing documentation bugs
+-   Improving clarity
+
+### How to Update
+
+1. Edit appropriate file in `docs/` or `.development-context/`
+2. Keep examples current
+3. Use clear language
+4. Test code examples
+5. Update table of contents if needed
+
+### Documentation Standards
+
+-   Use markdown for all docs
+-   Include code examples
+-   Use mermaid for diagrams
+-   Keep files focused and scannable
+-   Link related documents
+
+## Document Index
+
+### Getting Started
+
+-   [README.md](../README.md) - Project overview
+-   [CONTRIBUTING.md](../CONTRIBUTING.md) - How to contribute
+
+### Development
+
+-   [BEST_PRACTICES.md](BEST_PRACTICES.md) - Coding standards
+-   [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Problem solving
+-   [docker/README.md](../docker/README.md) - Docker guide
+
+### API
+
+-   [API.md](API.md) - API documentation
+-   [openapi.yaml](openapi.yaml) - OpenAPI specification
+-   [api-endpoints-reference.md](../.development-context/api-endpoints-reference.md) - Endpoint details
+
+### Architecture
+
+-   [ADRs](../.development-context/ADRs/) - Architecture decisions
+-   [rules](../.development-context/rules/) - Coding rules
+-   [PRDs](../.development-context/PRDs/) - Product requirements
+
+## Maintenance
+
+This documentation is maintained by the development team. Last updated: 2024-10-14.
+
+**Review Schedule:**
+
+-   Weekly: Update for new features
+-   Monthly: Review for accuracy
+-   Quarterly: Major revision and cleanup

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,684 @@
+# Troubleshooting Guide
+
+## Docker Issues
+
+### Container Won't Start
+
+**Symptom:** Container exits immediately or won't start
+
+**Solution:**
+
+```bash
+# Check logs for specific error
+just dev-logs
+
+# Check specific service
+just dev-logs php
+
+# Verify health status
+docker compose -f compose.yml -f compose.dev.yml ps
+
+# Check resource usage
+docker stats
+```
+
+**Common Causes:**
+
+-   Port already in use
+-   Insufficient memory
+-   Configuration error
+-   Missing environment variables
+
+### Port Already in Use
+
+**Symptom:** Error: `Bind for 0.0.0.0:8000 failed: port is already allocated`
+
+**Solution:**
+
+```bash
+# Find process using port
+lsof -i :8000
+
+# Kill process
+kill -9 <PID>
+
+# Or change port in compose.yml
+# ports:
+#   - "8001:80"  # Use 8001 instead
+```
+
+### Permission Errors
+
+**Symptom:** Permission denied errors in logs or when accessing files
+
+**Solution:**
+
+```bash
+# Set correct user/group IDs
+echo "USER_ID=$(id -u)" >> .env
+echo "GROUP_ID=$(id -g)" >> .env
+
+# Rebuild containers
+just build-dev
+
+# Fix file ownership
+docker compose -f compose.yml -f compose.dev.yml exec php chown -R www-data:www-data storage bootstrap/cache
+```
+
+### Database Connection Failed
+
+**Symptom:** `SQLSTATE[08006] [7] could not connect to server`
+
+**Solution:**
+
+```bash
+# Verify PostgreSQL is running and healthy
+docker compose -f compose.yml -f compose.dev.yml exec postgres pg_isready
+
+# Check connection from PHP container
+docker compose -f compose.yml -f compose.dev.yml exec php php artisan tinker
+> DB::connection()->getPdo();
+
+# Verify environment variables
+docker compose -f compose.yml -f compose.dev.yml exec php env | grep DB_
+
+# Check PostgreSQL logs
+just dev-logs postgres
+
+# Recreate database
+just migrate-fresh
+```
+
+### Redis Connection Failed
+
+**Symptom:** `Connection refused [tcp://redis:6379]`
+
+**Solution:**
+
+```bash
+# Check Redis is running
+docker compose -f compose.yml -f compose.dev.yml exec redis redis-cli ping
+
+# Test connection from PHP
+docker compose -f compose.yml -f compose.dev.yml exec php php artisan tinker
+> Redis::ping();
+
+# Check Redis logs
+just dev-logs redis
+
+# Restart Redis
+docker compose -f compose.yml -f compose.dev.yml restart redis
+```
+
+### Slow Performance on macOS
+
+**Symptom:** Extremely slow page loads (>10s)
+
+**Solution:**
+
+```bash
+# 1. Use cached volume mounts (already configured)
+# volumes:
+#   - ./:/var/www/html:cached
+
+# 2. Use named volumes for vendor/node_modules
+# volumes:
+#   - composer_cache:/var/www/html/vendor
+#   - node_modules:/var/www/html/node_modules
+
+# 3. Increase Docker Desktop resources
+# Docker Desktop → Preferences → Resources
+# - CPUs: 4+
+# - Memory: 8GB+
+# - Swap: 2GB+
+
+# 4. Enable VirtioFS
+# Docker Desktop → Preferences → Experimental Features
+# ✓ Use new Virtualization framework
+# ✓ Enable VirtioFS
+
+# 5. Use mutagen or docker-sync (advanced)
+```
+
+### Out of Disk Space
+
+**Symptom:** `no space left on device`
+
+**Solution:**
+
+```bash
+# Check Docker disk usage
+docker system df
+
+# Clean up unused resources
+docker system prune -a --volumes
+
+# Remove specific volumes
+docker volume ls
+docker volume rm <volume_name>
+
+# Clean Laravel caches
+just clean-cache
+
+# Remove old images
+docker image prune -a
+```
+
+### Container Keeps Restarting
+
+**Symptom:** Container in restart loop
+
+**Solution:**
+
+```bash
+# Check exit code
+docker compose -f compose.yml -f compose.dev.yml ps
+
+# View full logs
+just dev-logs
+
+# Disable restart to debug
+# In compose file: restart: "no"
+
+# Check health checks
+docker inspect <container_id> | grep -A 10 Health
+```
+
+## Laravel Issues
+
+### 500 Internal Server Error
+
+**Symptom:** White screen or 500 error
+
+**Solution:**
+
+```bash
+# Check Laravel logs
+tail -f storage/logs/laravel.log
+
+# Check Docker logs
+just dev-logs php
+
+# Enable debug mode
+# .env: APP_DEBUG=true
+
+# Clear caches
+just clean-cache
+
+# Check permissions
+docker compose -f compose.yml -f compose.dev.yml exec php \
+  chmod -R 775 storage bootstrap/cache
+```
+
+### Class Not Found
+
+**Symptom:** `Class 'App\...' not found`
+
+**Solution:**
+
+```bash
+# Regenerate autoload files
+just composer dump-autoload
+
+# Clear config cache
+just artisan config:clear
+
+# Rebuild containers
+just build-dev
+```
+
+### Migration Failed
+
+**Symptom:** Migration errors or database schema issues
+
+**Solution:**
+
+```bash
+# Check migration status
+just artisan migrate:status
+
+# Rollback last migration
+just migrate-rollback
+
+# Fresh migration (WARNING: drops all data)
+just migrate-fresh
+
+# Reset database
+just artisan migrate:fresh --seed
+
+# Check for pending migrations
+just artisan migrate:status
+
+# Fix migration manually in database
+just psql
+> DELETE FROM migrations WHERE migration = 'xxxx_migration_name';
+```
+
+### Queue Not Processing
+
+**Symptom:** Jobs stuck in queue
+
+**Solution:**
+
+```bash
+# Check queue worker is running
+docker compose -f compose.yml -f compose.dev.yml ps | grep queue
+
+# View queue status
+just artisan queue:work --once
+
+# Clear failed jobs
+just artisan queue:flush
+
+# Restart queue workers
+docker compose -f compose.yml -f compose.dev.yml restart queue
+
+# Check Redis connection
+just redis-cli
+> KEYS queue:*
+```
+
+### Cache Issues
+
+**Symptom:** Old data showing, changes not reflecting
+
+**Solution:**
+
+```bash
+# Clear all caches
+just clean-cache
+
+# Or individually
+just artisan cache:clear
+just artisan config:clear
+just artisan route:clear
+just artisan view:clear
+
+# Clear OPcache (production)
+just artisan opcache:clear
+
+# Restart PHP-FPM
+docker compose -f compose.yml -f compose.dev.yml restart php
+```
+
+## Testing Issues
+
+### Tests Failing Locally
+
+**Symptom:** Tests pass in CI but fail locally (or vice versa)
+
+**Solution:**
+
+```bash
+# Use test environment
+docker compose -f compose.yml -f compose.test.yml run --rm app-test php artisan test
+
+# Clean test database
+docker compose -f compose.yml -f compose.test.yml down -v
+
+# Check test environment variables
+cat phpunit.xml | grep env
+
+# Run specific test
+just test --filter=CategoryTest
+
+# Verbose output
+just test --testdox
+```
+
+### Database Seeding Issues
+
+**Symptom:** Seeder errors or constraint violations
+
+**Solution:**
+
+```bash
+# Fresh database with seeding
+just migrate-fresh
+
+# Run specific seeder
+just artisan db:seed --class=CategorySeeder
+
+# Check for foreign key issues
+just psql
+> SELECT * FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY';
+```
+
+## Build Issues
+
+### Composer Install Fails
+
+**Symptom:** Composer dependency resolution errors
+
+**Solution:**
+
+```bash
+# Update composer
+just composer self-update
+
+# Clear composer cache
+just composer clear-cache
+
+# Remove lock file and reinstall
+rm composer.lock
+just composer install
+
+# Check PHP version
+just composer show php
+```
+
+### NPM Install Fails
+
+**Symptom:** Node module installation errors
+
+**Solution:**
+
+```bash
+# Clear npm cache
+just npm-install
+docker compose -f compose.yml -f compose.dev.yml exec node npm cache clean --force
+
+# Remove node_modules and reinstall
+docker compose -f compose.yml -f compose.dev.yml exec node rm -rf node_modules
+just npm-install
+
+# Check Node version
+docker compose -f compose.yml -f compose.dev.yml exec node node --version
+```
+
+### Image Build Fails
+
+**Symptom:** Docker build errors
+
+**Solution:**
+
+```bash
+# Build without cache
+just build-dev
+
+# Or
+docker compose -f compose.yml -f compose.dev.yml build --no-cache
+
+# Check Dockerfile syntax
+docker build --check docker/php/Dockerfile.dev
+
+# Increase Docker build memory
+# Docker Desktop → Preferences → Resources
+```
+
+## Code Quality Issues
+
+### PHPStan Errors
+
+**Symptom:** Static analysis failures
+
+**Solution:**
+
+```bash
+# Run PHPStan with verbose output
+just phpstan-verbose
+
+# Generate baseline (temporary)
+just artisan phpstan:baseline
+
+# Check specific file
+docker compose -f compose.yml -f compose.dev.yml exec php \
+  ./vendor/bin/phpstan analyse app/Domains/Categories
+
+# Clear PHPStan cache
+rm -rf storage/phpstan
+```
+
+### Pint (Code Style) Errors
+
+**Symptom:** Code style violations
+
+**Solution:**
+
+```bash
+# Auto-fix all style issues
+just pint
+
+# Check without fixing
+just pint-test
+
+# Fix specific directory
+docker compose -f compose.yml -f compose.dev.yml exec php \
+  ./vendor/bin/pint app/Domains/Categories
+```
+
+## Development Workflow Issues
+
+### Hot Reload Not Working
+
+**Symptom:** Changes not reflected without manual refresh
+
+**Solution:**
+
+```bash
+# Check Vite is running
+just vite-logs
+
+# Restart Vite
+docker compose -f compose.yml -f compose.dev.yml restart node
+
+# Check Vite configuration
+cat vite.config.js
+
+# Verify volume mounts
+docker compose -f compose.yml -f compose.dev.yml config | grep volumes
+
+# Clear browser cache
+# Cmd+Shift+R (macOS) or Ctrl+Shift+R (Windows/Linux)
+```
+
+### Xdebug Not Working
+
+**Symptom:** Breakpoints not hit
+
+**Solution:**
+
+```bash
+# Verify Xdebug is loaded
+docker compose -f compose.yml -f compose.dev.yml exec php php -m | grep xdebug
+
+# Check Xdebug configuration
+docker compose -f compose.yml -f compose.dev.yml exec php php -i | grep xdebug
+
+# Check IDE configuration
+# PHPStorm: Settings → PHP → Debug
+# - Port: 9003
+# - Break at first line: enabled
+# - Path mappings: /var/www/html → /your/local/path
+
+# Set environment variable
+export XDEBUG_SESSION=1
+
+# Check firewall
+# Ensure port 9003 is not blocked
+```
+
+### Environment Variables Not Loading
+
+**Symptom:** `.env` changes not reflecting
+
+**Solution:**
+
+```bash
+# Restart containers
+docker compose -f compose.yml -f compose.dev.yml restart
+
+# Clear config cache
+just artisan config:clear
+
+# Verify .env is mounted
+docker compose -f compose.yml -f compose.dev.yml exec php cat .env
+
+# Check for syntax errors in .env
+cat .env | grep -v '^#' | grep -v '^$'
+```
+
+## Production Issues
+
+### Application Down
+
+**Symptom:** 502/503 errors
+
+**Solution:**
+
+```bash
+# Check all services
+docker compose -f compose.yml -f compose.prod.yml ps
+
+# Check health
+docker compose -f compose.yml -f compose.prod.yml exec php php artisan health:check
+
+# Check logs
+just prod-logs
+
+# Restart services
+docker compose -f compose.yml -f compose.prod.yml restart
+```
+
+### High Memory Usage
+
+**Symptom:** Containers consuming excessive memory
+
+**Solution:**
+
+```bash
+# Check memory usage
+docker stats
+
+# Optimize OPcache
+# php-prod.ini:
+# opcache.memory_consumption=256
+
+# Increase container limits
+# compose.prod.yml:
+# deploy:
+#   resources:
+#     limits:
+#       memory: 1G
+
+# Check for memory leaks
+just artisan queue:work --max-jobs=100 --max-time=3600
+```
+
+### High CPU Usage
+
+**Symptom:** CPU at 100%
+
+**Solution:**
+
+```bash
+# Identify process
+docker stats
+docker top <container_id>
+
+# Check for infinite loops in code
+# Check queue workers processing correctly
+# Check scheduler not running too frequently
+
+# Limit CPU usage
+# compose.prod.yml:
+# deploy:
+#   resources:
+#     limits:
+#       cpus: '2.0'
+```
+
+## Getting Help
+
+### Logs to Collect
+
+When reporting issues, include:
+
+```bash
+# System information
+docker --version
+docker compose version
+php --version
+
+# Service status
+docker compose -f compose.yml -f compose.dev.yml ps
+
+# Recent logs
+just dev-logs --tail=100 > logs.txt
+
+# Laravel logs
+tail -n 100 storage/logs/laravel.log
+
+# Environment (sanitized)
+cat .env | grep -v PASSWORD | grep -v SECRET
+```
+
+### Nuclear Option: Start Fresh
+
+If all else fails:
+
+```bash
+# Stop everything
+just dev-stop
+
+# Remove all containers and volumes
+just clean
+
+# Remove Docker images
+docker image prune -a
+
+# Fresh setup
+just setup
+
+# Verify
+just health
+```
+
+### Support Channels
+
+1. Check [README.md](../README.md) for setup instructions
+2. Review [docker/README.md](../docker/README.md) for Docker details
+3. Check [.development-context/](../.development-context/) for architecture docs
+4. Run `just health` for diagnostics
+5. Check `storage/logs/` for application logs
+
+## Common Error Messages
+
+### `Connection refused`
+
+-   Service not running
+-   Wrong host/port
+-   Network isolation issue
+-   Health check failing
+
+### `Permission denied`
+
+-   File ownership issue
+-   Volume mount permissions
+-   User/group ID mismatch
+
+### `No space left on device`
+
+-   Disk full
+-   Docker storage full
+-   Log files too large
+
+### `Address already in use`
+
+-   Port conflict
+-   Service already running
+-   Previous container not stopped
+
+### `SQLSTATE[HY000]`
+
+-   Database connection issue
+-   Wrong credentials
+-   Database not initialized
+-   Network issue
+
+### `Class not found`
+
+-   Autoload not regenerated
+-   Missing composer install
+-   Wrong namespace
+-   File not in correct location

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1032 @@
+openapi: 3.0.3
+info:
+  title: Junction Bank API
+  description: |
+    Domain-driven personal finance management system API.
+
+    ## Authentication
+    All authenticated endpoints require a Bearer token via Laravel Sanctum.
+
+    ## Rate Limiting
+    - Authenticated: 120 requests/minute
+    - Import endpoints: 10 requests/minute
+    - Auth endpoints: 10 requests/minute
+
+  version: 1.0.0
+  contact:
+    name: Junction Bank Development
+  license:
+    name: Proprietary
+
+servers:
+  - url: http://localhost:8000/api
+    description: Development server
+  - url: https://api.junctionbank.com/api
+    description: Production server
+
+tags:
+  - name: Authentication
+    description: User authentication and registration
+  - name: Categories
+    description: Category management
+  - name: Transactions
+    description: Transaction management and CSV import
+  - name: Recurring Transactions
+    description: Recurring transaction patterns
+  - name: Months
+    description: Monthly budget periods
+
+security:
+  - bearerAuth: []
+
+paths:
+  # Authentication
+  /auth/register:
+    post:
+      tags: [Authentication]
+      summary: Register new user
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, email, password, password_confirmation]
+              properties:
+                name:
+                  type: string
+                  example: John Doe
+                email:
+                  type: string
+                  format: email
+                  example: john@example.com
+                password:
+                  type: string
+                  format: password
+                  minLength: 8
+                  example: SecurePassword123!
+                password_confirmation:
+                  type: string
+                  format: password
+                  example: SecurePassword123!
+      responses:
+        "201":
+          description: User registered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      user:
+                        $ref: "#/components/schemas/User"
+                      token:
+                        type: string
+                        example: "1|abc123def456..."
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /auth/login:
+    post:
+      tags: [Authentication]
+      summary: Login user
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: john@example.com
+                password:
+                  type: string
+                  format: password
+                  example: SecurePassword123!
+      responses:
+        "200":
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      user:
+                        $ref: "#/components/schemas/User"
+                      token:
+                        type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/logout:
+    post:
+      tags: [Authentication]
+      summary: Logout user
+      responses:
+        "200":
+          description: Logout successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+
+  /auth/me:
+    get:
+      tags: [Authentication]
+      summary: Get current user
+      responses:
+        "200":
+          description: Current user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/User"
+
+  # Categories
+  /categories:
+    get:
+      tags: [Categories]
+      summary: List all categories
+      responses:
+        "200":
+          description: List of categories
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Category"
+
+    post:
+      tags: [Categories]
+      summary: Create category
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CategoryInput"
+      responses:
+        "201":
+          description: Category created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Category"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /categories/{id}:
+    parameters:
+      - $ref: "#/components/parameters/CategoryId"
+
+    get:
+      tags: [Categories]
+      summary: Get category by ID
+      responses:
+        "200":
+          description: Category details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Category"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      tags: [Categories]
+      summary: Delete category
+      responses:
+        "200":
+          description: Category deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  # Transactions
+  /transactions:
+    get:
+      tags: [Transactions]
+      summary: List transactions
+      parameters:
+        - name: monthId
+          in: query
+          description: Filter by month ID
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: List of transactions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Transaction"
+
+    post:
+      tags: [Transactions]
+      summary: Create transaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransactionInput"
+      responses:
+        "201":
+          description: Transaction created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Transaction"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /transactions/{id}:
+    parameters:
+      - $ref: "#/components/parameters/TransactionId"
+
+    get:
+      tags: [Transactions]
+      summary: Get transaction by ID
+      responses:
+        "200":
+          description: Transaction details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Transaction"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      tags: [Transactions]
+      summary: Update transaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransactionInput"
+      responses:
+        "200":
+          description: Transaction updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Transaction"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      tags: [Transactions]
+      summary: Delete transaction
+      responses:
+        "200":
+          description: Transaction deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /transactions/preview:
+    post:
+      tags: [Transactions]
+      summary: Preview CSV import
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: CSV file with transactions
+      responses:
+        "200":
+          description: Import preview
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportPreview"
+
+  /transactions/import:
+    post:
+      tags: [Transactions]
+      summary: Import validated transactions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [transactions]
+              properties:
+                transactions:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/TransactionInput"
+      responses:
+        "200":
+          description: Import successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportResult"
+
+  # Months
+  /months:
+    get:
+      tags: [Months]
+      summary: List months
+      parameters:
+        - name: year
+          in: query
+          schema:
+            type: integer
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 12
+      responses:
+        "200":
+          description: List of months
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Month"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+
+    post:
+      tags: [Months]
+      summary: Create month
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MonthInput"
+      responses:
+        "201":
+          description: Month created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Month"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /months/latest:
+    get:
+      tags: [Months]
+      summary: Get latest month
+      responses:
+        "200":
+          description: Latest month
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonthDetailed"
+
+  /months/{id}:
+    parameters:
+      - $ref: "#/components/parameters/MonthId"
+
+    get:
+      tags: [Months]
+      summary: Get month by ID
+      responses:
+        "200":
+          description: Month details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonthDetailed"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      tags: [Months]
+      summary: Update month
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MonthInput"
+      responses:
+        "200":
+          description: Month updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Month"
+
+    delete:
+      tags: [Months]
+      summary: Delete month
+      responses:
+        "200":
+          description: Month deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /months/{id}/spending:
+    parameters:
+      - $ref: "#/components/parameters/MonthId"
+    get:
+      tags: [Months]
+      summary: Get spending by category
+      responses:
+        "200":
+          description: Category spending
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CategorySpending"
+
+  /months/recalculate:
+    post:
+      tags: [Months]
+      summary: Recalculate recurring expenses
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                monthId:
+                  type: integer
+                  nullable: true
+      responses:
+        "200":
+          description: Recalculation complete
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                  monthsUpdated:
+                    type: integer
+
+  # Recurring Transactions
+  /recurring-transactions:
+    get:
+      tags: [Recurring Transactions]
+      summary: List recurring transactions
+      responses:
+        "200":
+          description: List of recurring transactions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RecurringTransaction"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+
+    post:
+      tags: [Recurring Transactions]
+      summary: Create recurring transaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecurringTransactionInput"
+      responses:
+        "201":
+          description: Recurring transaction created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RecurringTransaction"
+
+  /recurring-transactions/{id}:
+    parameters:
+      - $ref: "#/components/parameters/RecurringTransactionId"
+
+    get:
+      tags: [Recurring Transactions]
+      summary: Get recurring transaction by ID
+      responses:
+        "200":
+          description: Recurring transaction details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecurringTransaction"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      tags: [Recurring Transactions]
+      summary: Update recurring transaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecurringTransactionInput"
+      responses:
+        "200":
+          description: Recurring transaction updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecurringTransaction"
+
+    delete:
+      tags: [Recurring Transactions]
+      summary: Delete recurring transaction
+      responses:
+        "200":
+          description: Recurring transaction deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: Sanctum
+
+  parameters:
+    CategoryId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Category ID
+
+    TransactionId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Transaction ID
+
+    MonthId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Month ID
+
+    RecurringTransactionId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Recurring transaction ID
+
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        created_at:
+          type: string
+          format: date-time
+
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        type:
+          type: string
+          enum: [income, expense]
+        notes:
+          type: string
+          nullable: true
+        isRecurring:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+
+    CategoryInput:
+      type: object
+      required: [name, type]
+      properties:
+        name:
+          type: string
+          example: Groceries
+        type:
+          type: string
+          enum: [income, expense]
+          example: expense
+        notes:
+          type: string
+          nullable: true
+
+    Transaction:
+      type: object
+      properties:
+        id:
+          type: integer
+        clerkId:
+          type: string
+        name:
+          type: string
+        amountCAD:
+          type: number
+          format: decimal
+        amountUSD:
+          type: number
+          format: decimal
+          nullable: true
+        categoryId:
+          type: integer
+        categoryName:
+          type: string
+        notes:
+          type: string
+          nullable: true
+        type:
+          type: string
+          enum: [Income, Expense]
+        date:
+          type: string
+          format: date
+        monthId:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+
+    TransactionInput:
+      type: object
+      required: [name, amountCAD, categoryId, date, monthId]
+      properties:
+        name:
+          type: string
+        amountCAD:
+          type: number
+          format: decimal
+        amountUSD:
+          type: number
+          format: decimal
+          nullable: true
+        categoryId:
+          type: integer
+        notes:
+          type: string
+          nullable: true
+        type:
+          type: string
+          enum: [Income, Expense]
+          default: Expense
+        date:
+          type: string
+          format: date
+        monthId:
+          type: integer
+
+    Month:
+      type: object
+      properties:
+        id:
+          type: integer
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        year:
+          type: integer
+        notes:
+          type: string
+          nullable: true
+        totalIncome:
+          type: number
+          format: decimal
+        totalExpenses:
+          type: number
+          format: decimal
+        recurringExpenses:
+          type: number
+          format: decimal
+        transactionCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+
+    MonthDetailed:
+      allOf:
+        - $ref: "#/components/schemas/Month"
+        - type: object
+          properties:
+            calculated:
+              type: object
+              properties:
+                cashflow:
+                  type: number
+                nonRecurringExpenses:
+                  type: number
+                projectedDailyBudget:
+                  type: number
+                remainingDailyBudget:
+                  type: number
+                actualDailySpend:
+                  type: number
+                daysTotal:
+                  type: integer
+                daysLeft:
+                  type: integer
+                daysPassed:
+                  type: integer
+                isCurrentMonth:
+                  type: boolean
+
+    MonthInput:
+      type: object
+      required: [month, year]
+      properties:
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        year:
+          type: integer
+          minimum: 1900
+          maximum: 2100
+        notes:
+          type: string
+          nullable: true
+
+    RecurringTransaction:
+      type: object
+      properties:
+        id:
+          type: integer
+        clerkId:
+          type: string
+        name:
+          type: string
+        amountCAD:
+          type: number
+          format: decimal
+          nullable: true
+        amountUSD:
+          type: number
+          format: decimal
+          nullable: true
+        categoryId:
+          type: integer
+        categoryName:
+          type: string
+        notes:
+          type: string
+          nullable: true
+        dayOfMonth:
+          type: integer
+          minimum: 1
+          maximum: 31
+          nullable: true
+        type:
+          type: string
+          enum: [Income, Expense]
+        createdAt:
+          type: string
+          format: date-time
+
+    RecurringTransactionInput:
+      type: object
+      required: [name, categoryId]
+      properties:
+        name:
+          type: string
+        amountCAD:
+          type: number
+          format: decimal
+          nullable: true
+        amountUSD:
+          type: number
+          format: decimal
+          nullable: true
+        categoryId:
+          type: integer
+        notes:
+          type: string
+          nullable: true
+        dayOfMonth:
+          type: integer
+          minimum: 1
+          maximum: 31
+          nullable: true
+        type:
+          type: string
+          enum: [Income, Expense]
+          default: Expense
+
+    CategorySpending:
+      type: object
+      properties:
+        categoryId:
+          type: integer
+        categoryName:
+          type: string
+        totalAmountCAD:
+          type: string
+        totalAmountUSD:
+          type: string
+        total:
+          type: number
+
+    ImportPreview:
+      type: object
+      properties:
+        validTransactions:
+          type: array
+          items:
+            $ref: "#/components/schemas/TransactionInput"
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              row:
+                type: integer
+              message:
+                type: string
+              originalData:
+                type: object
+        summary:
+          type: object
+          properties:
+            totalRows:
+              type: integer
+            validRows:
+              type: integer
+            errorRows:
+              type: integer
+
+    ImportResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        summary:
+          type: object
+          properties:
+            imported:
+              type: integer
+            failed:
+              type: integer
+            totalProcessed:
+              type: integer
+        createdTransactions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Transaction"
+
+    Pagination:
+      type: object
+      properties:
+        currentPage:
+          type: integer
+        totalPages:
+          type: integer
+        totalItems:
+          type: integer
+        perPage:
+          type: integer
+        hasNext:
+          type: boolean
+        hasPrev:
+          type: boolean
+
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            message:
+              type: string
+            code:
+              type: string
+            details:
+              type: object
+              additionalProperties: true
+
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    ValidationError:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    Conflict:
+      description: Resource conflict (duplicate or constraint violation)
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"

--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ test-arch:
     docker compose -f compose.yml -f compose.test.yml down -v
 
 # Run all quality checks
-test-all: test test-phpstan test-cs test-arch
+test-all: test phpstan pint-test test-arch
 
 # Application Commands
 # ====================


### PR DESCRIPTION
## Summary
Creates foundational database schema for Categories domain per PRD specification.

## Changes
- Updated `config/database.php` to use PostgreSQL as default database
- Added `categories` table migration with:
  - Columns: id, name, type, notes, is_recurring, timestamps
  - Unique constraint on name
  - Indexes on type and is_recurring
  
## Testing
Testing continues to use SQLite (configured in phpunit.xml).

## Validation
Manual validation checklist from TICKET-001:
- [x] Migration runs: `php artisan migrate`
- [x] Table exists in database
- [x] Unique constraint enforced on name
- [ ] Enum constraint enforced on type
- [ ] Rollback works: `php artisan migrate:rollback`
- [ ] Re-migration successful

## Implementation
- Branch: `feature/cat-01-cat-schema`
- Commit: 998c15bd
- Implements: TICKET-001